### PR TITLE
changing arb goerli to arb sepolia

### DIFF
--- a/examples/eth/index.ts
+++ b/examples/eth/index.ts
@@ -1,6 +1,6 @@
 import { Chain, createPublicClient, http } from 'viem';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
-import { arbitrumGoerli } from 'viem/chains';
+import { arbitrumSepolia } from 'viem/chains';
 import {
   createRollupPrepareConfig,
   prepareChainConfig,
@@ -42,7 +42,7 @@ const validatorPrivateKey = withFallbackPrivateKey(process.env.VALIDATOR_PRIVATE
 const validator = privateKeyToAccount(validatorPrivateKey).address;
 
 // set the parent chain and create a public client for it
-const parentChain = arbitrumGoerli;
+const parentChain = arbitrumSepolia;
 const parentChainPublicClient = createPublicClient({ chain: parentChain, transport: http() });
 
 // load the deployer account


### PR DESCRIPTION
Because we just have Arb Sepolia and Sepolia chains defined for rollup creation, Arb Goerli txs would be rejected so this script can't be executed. I've decided to change it to Arb Sepolia and not adding Arb Goerli to the chain list cause Arb Goerli is going to be depreciated.
