### PR TITLE
fix: properly set callvalue in create rollup

### DIFF
--- a/src/createRollup.integration.test.ts
+++ b/src/createRollup.integration.test.ts
@@ -74,4 +74,5 @@ it(`successfully deploys core contracts through rollup creator`, async () => {
   );
 
   expect(txReceipt.status).toEqual('success');
+  expect(txReceipt.getCoreContracts()).not.toThrowError();
 });

--- a/src/createRollup.integration.test.ts
+++ b/src/createRollup.integration.test.ts
@@ -74,5 +74,5 @@ it(`successfully deploys core contracts through rollup creator`, async () => {
   );
 
   expect(txReceipt.status).toEqual('success');
-  expect(txReceipt.getCoreContracts()).not.toThrowError();
+  expect(() => txReceipt.getCoreContracts()).not.toThrowError();
 });

--- a/src/createRollup.ts
+++ b/src/createRollup.ts
@@ -58,13 +58,14 @@ export async function createRollup({
   }
 
   const maxDataSize = createRollupGetMaxDataSize(chainId);
+  const paramsWithDefaults = { ...defaults, ...params, maxDataSize };
 
   const { request } = await publicClient.simulateContract({
     address: rollupCreator.address[chainId],
     abi: rollupCreator.abi,
     functionName: 'createRollup',
-    args: [{ ...defaults, ...params, maxDataSize }],
-    value: createRollupGetCallValue(params),
+    args: [paramsWithDefaults],
+    value: createRollupGetCallValue(paramsWithDefaults),
     account,
   });
 

--- a/src/createRollupPrepareTransactionRequest.ts
+++ b/src/createRollupPrepareTransactionRequest.ts
@@ -1,6 +1,6 @@
 import { Address, PublicClient, encodeFunctionData } from 'viem';
 
-import { CreateRollupParams } from './createRollup';
+import { CreateRollupFunctionInputs, CreateRollupParams } from './createRollup';
 import { defaults } from './createRollupDefaults';
 import { createRollupGetCallValue } from './createRollupGetCallValue';
 import { createRollupGetMaxDataSize } from './createRollupGetMaxDataSize';
@@ -10,13 +10,11 @@ import { isCustomFeeTokenAddress } from './utils/isCustomFeeTokenAddress';
 import { ChainConfig } from './types/ChainConfig';
 import { isAnyTrustChainConfig } from './utils/isAnyTrustChainConfig';
 
-function createRollupEncodeFunctionData(
-  params: CreateRollupParams & { maxDataSize: bigint }
-) {
+function createRollupEncodeFunctionData(args: CreateRollupFunctionInputs) {
   return encodeFunctionData({
     abi: rollupCreator.abi,
     functionName: 'createRollup',
-    args: [{ ...defaults, ...params }],
+    args,
   });
 }
 
@@ -47,12 +45,13 @@ export async function createRollupPrepareTransactionRequest({
   }
 
   const maxDataSize = createRollupGetMaxDataSize(chainId);
+  const paramsWithDefaults = { ...defaults, ...params, maxDataSize };
 
   const request = await publicClient.prepareTransactionRequest({
     chain: publicClient.chain,
     to: rollupCreator.address[chainId],
-    data: createRollupEncodeFunctionData({ ...params, maxDataSize }),
-    value: createRollupGetCallValue(params),
+    data: createRollupEncodeFunctionData([paramsWithDefaults]),
+    value: createRollupGetCallValue(paramsWithDefaults),
     account,
   });
 


### PR DESCRIPTION
The function `createRollupGetCallValue` was being called without applying defaults, which means `params.deployFactoriesToL2` was set to `false` (even though are defaults set it to `true`) so the call value was always 0. 

Now we properly apply defaults to input params first.

I also added one extra assertion to make sure everything was executed properly and the logs can be successfully decoded.

The test failing in CI should be ignored as it's not set up properly, and should be tried out locally.