### PR TITLE
ci: update nitro-testnode params

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install node_modules
         uses: OffchainLabs/actions/node-modules/install@main
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main
@@ -67,7 +67,7 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          nitro-testnode-ref: 'use-tokenbridge-creator'
+          nitro-testnode-ref: use-tokenbridge-creator
           # we have RollupCreator on L1 by default
           # --tokenbridge is there to ensure we have TokenBridgeCreator on L1
           # --l3node is there to ensure we have RollupCreator on L2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,7 +65,7 @@ jobs:
         uses: OffchainLabs/actions/node-modules/restore@main
 
       - name: Set up the local node
-        uses: OffchainLabs/actions/run-nitro-test-node@debug
+        uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
           nitro-testnode-ref: use-tokenbridge-creator
           # we have RollupCreator on L1 by default

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          nitro-testnode-ref: use-tokenbridge-creator-docker-compose-patch
-          # don't deploy the regular token bridge using arbitrum-sdk
+          nitro-testnode-ref: use-tokenbridge-creator
+          # don't deploy the regular token bridge using arbitrum-sdk, as it will be deployed through the TokenBridgeCreator
           no-token-bridge: true
           # RollupCreator on L1 is deployed by default
           # RollupCreator on L2 is deployed with --l3node

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,13 +67,9 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@debug
         with:
-          nitro-testnode-ref: use-tokenbridge-creator
           # we have RollupCreator on L1 by default
           # --l3node (ensure we have RollupCreator on L2)
           l3-node: true
-          # --tokenbridge (ensure we have TokenBridgeCreator on L1)
-          # --l3-token-bridge (ensure we have TokenBridgeCreator on L2)
-          args: --tokenbridge --l3-token-bridge
 
       - name: Copy .env
         run: cp ./.env.example ./.env

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,10 +65,10 @@ jobs:
         uses: OffchainLabs/actions/node-modules/restore@main
 
       - name: Set up the local node
-        uses: OffchainLabs/actions/run-nitro-test-node@debug
+        uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          # we have RollupCreator on L1 by default
-          # --l3node (ensure we have RollupCreator on L2)
+          # RollupCreator on L1 is deployed by default
+          # RollupCreator on L2 is deployed with --l3node
           l3-node: true
 
       - name: Copy .env

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
 
       - name: Install node_modules
         uses: OffchainLabs/actions/node-modules/install@main
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
 
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
 
       - name: Restore node_modules
         uses: OffchainLabs/actions/node-modules/restore@main

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,7 +70,7 @@ jobs:
           nitro-testnode-ref: use-tokenbridge-creator
           # we have RollupCreator on L1 by default
           # --l3node (ensure we have RollupCreator on L2)
-          l3node: true
+          l3-node: true
           # --tokenbridge (ensure we have TokenBridgeCreator on L1)
           # --l3-token-bridge (ensure we have TokenBridgeCreator on L2)
           args: --tokenbridge --l3-token-bridge

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          nitro-testnode-ref: use-tokenbridge-creator
+          nitro-testnode-ref: 'use-tokenbridge-creator'
           # we have RollupCreator on L1 by default
           # --tokenbridge is there to ensure we have TokenBridgeCreator on L1
           # --l3node is there to ensure we have RollupCreator on L2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,15 +53,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
-      - name: Check Docker Version
-        run: docker --version
-
-      - name: Check Docker Compose Version
-        run: docker compose version
-
-      - name: Check Docker-Compose Version
-        run: docker-compose version
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,10 +69,11 @@ jobs:
         with:
           nitro-testnode-ref: use-tokenbridge-creator
           # we have RollupCreator on L1 by default
-          # --tokenbridge is there to ensure we have TokenBridgeCreator on L1
-          # --l3node is there to ensure we have RollupCreator on L2
-          # --l3-token-bridge is there to ensure we have TokenBridgeCreator on L2
-          args: --tokenbridge --l3node --l3-token-bridge
+          # --l3node (ensure we have RollupCreator on L2)
+          l3node: true
+          # --tokenbridge (ensure we have TokenBridgeCreator on L1)
+          # --l3-token-bridge (ensure we have TokenBridgeCreator on L2)
+          args: --tokenbridge --l3-token-bridge
 
       - name: Copy .env
         run: cp ./.env.example ./.env

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,7 +65,7 @@ jobs:
         uses: OffchainLabs/actions/node-modules/restore@main
 
       - name: Set up the local node
-        uses: OffchainLabs/actions/run-nitro-test-node@main
+        uses: OffchainLabs/actions/run-nitro-test-node@debug
         with:
           nitro-testnode-ref: use-tokenbridge-creator
           # we have RollupCreator on L1 by default

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,12 +67,12 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          ref: 'use-tokenbridge-creator'
+          ref: use-tokenbridge-creator
           # we have RollupCreator on L1 by default
           # --tokenbridge is there to ensure we have TokenBridgeCreator on L1
           # --l3node is there to ensure we have RollupCreator on L2
           # --l3-token-bridge is there to ensure we have TokenBridgeCreator on L2
-          args: '--tokenbridge --l3node --l3-token-bridge'
+          args: --tokenbridge --l3node --l3-token-bridge
 
       - name: Copy .env
         run: cp ./.env.example ./.env

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check Docker Compose Version
         run: docker compose version
 
+      - name: Check Docker-Compose Version
+        run: docker-compose version
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          ref: use-tokenbridge-creator
+          nitro-testnode-ref: use-tokenbridge-creator
           # we have RollupCreator on L1 by default
           # --tokenbridge is there to ensure we have TokenBridgeCreator on L1
           # --l3node is there to ensure we have RollupCreator on L2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Check Docker Version
         run: docker --version
 
+      - name: Check Docker Compose Version
+        run: docker compose version
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,6 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - name: Check Docker Version
+        run: docker --version
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,6 +68,8 @@ jobs:
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
           nitro-testnode-ref: use-tokenbridge-creator-docker-compose-patch
+          # don't deploy the regular token bridge using arbitrum-sdk
+          no-token-bridge: true
           # RollupCreator on L1 is deployed by default
           # RollupCreator on L2 is deployed with --l3node
           l3-node: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          ref: 'use-tokenbridge-creator'
+          ref: use-tokenbridge-creator
+          args: --tokenbridge --l3node --l3-token-bridge
 
       - name: Copy .env
         run: cp ./.env.example ./.env

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          nitro-testnode-ref: use-tokenbridge-creator
+          nitro-testnode-ref: use-tokenbridge-creator-docker-compose-patch
           # RollupCreator on L1 is deployed by default
           # RollupCreator on L2 is deployed with --l3node
           l3-node: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,8 +67,12 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          ref: use-tokenbridge-creator
-          args: --tokenbridge --l3node --l3-token-bridge
+          ref: 'use-tokenbridge-creator'
+          # we have RollupCreator on L1 by default
+          # --tokenbridge is there to ensure we have TokenBridgeCreator on L1
+          # --l3node is there to ensure we have RollupCreator on L2
+          # --l3-token-bridg is there to ensure we have TokenBridgeCreator on L2
+          args: '--tokenbridge --l3node --l3-token-bridge'
 
       - name: Copy .env
         run: cp ./.env.example ./.env

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
+          nitro-testnode-ref: master
           # RollupCreator on L1 is deployed by default
           # RollupCreator on L2 is deployed with --l3node
           l3-node: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,9 +71,9 @@ jobs:
         uses: OffchainLabs/actions/node-modules/restore@main
 
       - name: Set up the local node
-        uses: OffchainLabs/actions/run-nitro-test-node@main
+        uses: OffchainLabs/actions/run-nitro-test-node@debug
         with:
-          nitro-testnode-ref: master
+          nitro-testnode-ref: use-tokenbridge-creator
           # RollupCreator on L1 is deployed by default
           # RollupCreator on L2 is deployed with --l3node
           l3-node: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,7 +71,7 @@ jobs:
           # we have RollupCreator on L1 by default
           # --tokenbridge is there to ensure we have TokenBridgeCreator on L1
           # --l3node is there to ensure we have RollupCreator on L2
-          # --l3-token-bridg is there to ensure we have TokenBridgeCreator on L2
+          # --l3-token-bridge is there to ensure we have TokenBridgeCreator on L2
           args: '--tokenbridge --l3node --l3-token-bridge'
 
       - name: Copy .env

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,12 +65,15 @@ jobs:
         uses: OffchainLabs/actions/node-modules/restore@main
 
       - name: Set up the local node
-        uses: OffchainLabs/actions/run-nitro-test-node@debug
+        uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
           nitro-testnode-ref: use-tokenbridge-creator
           # RollupCreator on L1 is deployed by default
           # RollupCreator on L2 is deployed with --l3node
           l3-node: true
+          # TokenBridgeCreator on L1 is deployed with --tokenbridge
+          # TokenBridgeCreator on L2 is deployed with --l3-token-bridge
+          args: --tokenbridge --l3-token-bridge
 
       - name: Copy .env
         run: cp ./.env.example ./.env

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -52,7 +52,7 @@ const contracts: ContractConfig[] = [
       // testnet
       [sepolia.id]: '0xfbd0b034e6305788007f6e0123cc5eae701a5751',
       [arbitrumSepolia.id]: '0x06E341073b2749e0Bb9912461351f716DeCDa9b0',
-      // local nitro-testnode (on "use-tokenbridge-creator" branch with --l3node flag)
+      // local nitro-testnode (on "use-tokenbridge-creator" branch with --tokenbridge --l3node --l3-token-bridge flags)
       [nitroTestnodeL1.id]: '0x596eabe0291d4cdafac7ef53d16c92bf6922b5e0',
       [nitroTestnodeL2.id]: '0x3BaF9f08bAD68869eEdEa90F2Cc546Bd80F1A651',
     },
@@ -64,7 +64,7 @@ const contracts: ContractConfig[] = [
       // testnet
       [sepolia.id]: '0x7612718D3143C791B2Ff5c01a9a7D02CEf00AE9c',
       [arbitrumSepolia.id]: '0xb462C69f8f638d2954c9618B03765FC1770190cF',
-      // local nitro-testnode (on "use-tokenbridge-creator" branch with --l3node flag)
+      // local nitro-testnode (on "use-tokenbridge-creator" branch with --tokenbridge --l3node --l3-token-bridge flags)
       [nitroTestnodeL1.id]: '0x4a2ba922052ba54e29c5417bc979daaf7d5fe4f4',
       [nitroTestnodeL2.id]: '0x38f35af53bf913c439eab06a367e09d6eb253492',
     },

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -52,7 +52,7 @@ const contracts: ContractConfig[] = [
       // testnet
       [sepolia.id]: '0xfbd0b034e6305788007f6e0123cc5eae701a5751',
       [arbitrumSepolia.id]: '0x06E341073b2749e0Bb9912461351f716DeCDa9b0',
-      // local nitro-testnode (on "use-tokenbridge-creator" branch)
+      // local nitro-testnode (on "use-tokenbridge-creator" branch with --tokenbridge --l3node --l3-token-bridge flags)
       [nitroTestnodeL1.id]: '0x596eabe0291d4cdafac7ef53d16c92bf6922b5e0',
       [nitroTestnodeL2.id]: '0x3BaF9f08bAD68869eEdEa90F2Cc546Bd80F1A651',
     },
@@ -64,7 +64,7 @@ const contracts: ContractConfig[] = [
       // testnet
       [sepolia.id]: '0x7612718D3143C791B2Ff5c01a9a7D02CEf00AE9c',
       [arbitrumSepolia.id]: '0xb462C69f8f638d2954c9618B03765FC1770190cF',
-      // local nitro-testnode (on "use-tokenbridge-creator" branch)
+      // local nitro-testnode (on "use-tokenbridge-creator" branch with --tokenbridge --l3node --l3-token-bridge flags)
       [nitroTestnodeL1.id]: '0x4a2ba922052ba54e29c5417bc979daaf7d5fe4f4',
       [nitroTestnodeL2.id]: '0x38f35af53bf913c439eab06a367e09d6eb253492',
     },

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -52,7 +52,7 @@ const contracts: ContractConfig[] = [
       // testnet
       [sepolia.id]: '0xfbd0b034e6305788007f6e0123cc5eae701a5751',
       [arbitrumSepolia.id]: '0x06E341073b2749e0Bb9912461351f716DeCDa9b0',
-      // local nitro-testnode (on "use-tokenbridge-creator" branch with --tokenbridge --l3node --l3-token-bridge flags)
+      // local nitro-testnode (on "use-tokenbridge-creator" branch with --l3node flag)
       [nitroTestnodeL1.id]: '0x596eabe0291d4cdafac7ef53d16c92bf6922b5e0',
       [nitroTestnodeL2.id]: '0x3BaF9f08bAD68869eEdEa90F2Cc546Bd80F1A651',
     },
@@ -64,7 +64,7 @@ const contracts: ContractConfig[] = [
       // testnet
       [sepolia.id]: '0x7612718D3143C791B2Ff5c01a9a7D02CEf00AE9c',
       [arbitrumSepolia.id]: '0xb462C69f8f638d2954c9618B03765FC1770190cF',
-      // local nitro-testnode (on "use-tokenbridge-creator" branch with --tokenbridge --l3node --l3-token-bridge flags)
+      // local nitro-testnode (on "use-tokenbridge-creator" branch with --l3node flag)
       [nitroTestnodeL1.id]: '0x4a2ba922052ba54e29c5417bc979daaf7d5fe4f4',
       [nitroTestnodeL2.id]: '0x38f35af53bf913c439eab06a367e09d6eb253492',
     },


### PR DESCRIPTION
Fixes argument `ref` to `nitro-testnode-ref` and adds the following flags:

```
// RollupCreator on L1 is deployed by default
--tokenbridge // this will make sure we have the TokenBridgeCreator deployed on L1
--l3node // this will make sure we have RollupCreator deployed on L2
--l3-token-bridge // this will make sure we have TokenBridgeCreator deployed on L2
```