### PR TITLE
fix: allow custom parent chain RPC (and fix bug)

### DIFF
--- a/examples/verify-rollup/.env.example
+++ b/examples/verify-rollup/.env.example
@@ -6,6 +6,7 @@ ORBIT_CHAIN_RPC=
 # Parent chain
 ##############
 PARENT_CHAIN_ID=
+PARENT_CHAIN_RPC=
 ROLLUP_ADDRESS=
 
 # For TokenBridge verification

--- a/examples/verify-rollup/src/lib/client.ts
+++ b/examples/verify-rollup/src/lib/client.ts
@@ -8,12 +8,12 @@ export class OrbitHandler {
   parentChainPublicClient: PublicClient;
   orbitPublicClient: PublicClient | undefined;
 
-  constructor(parentChainId: number, orbitChainId?: number, orbitChainRpc?: string) {
+  constructor(parentChainId: number, parentChainRpc?: string, orbitChainId?: number, orbitChainRpc?: string) {
     // Create parent chain client
     const parentChainInformation = getChainInfoFromChainId(parentChainId);
     this.parentChainPublicClient = createPublicClient({
       chain: parentChainInformation,
-      transport: http(),
+      transport: http(parentChainRpc),
     });
 
     // Create orbit chain client

--- a/examples/verify-rollup/src/lib/client.ts
+++ b/examples/verify-rollup/src/lib/client.ts
@@ -8,7 +8,12 @@ export class OrbitHandler {
   parentChainPublicClient: PublicClient;
   orbitPublicClient: PublicClient | undefined;
 
-  constructor(parentChainId: number, parentChainRpc?: string, orbitChainId?: number, orbitChainRpc?: string) {
+  constructor(
+    parentChainId: number,
+    parentChainRpc?: string,
+    orbitChainId?: number,
+    orbitChainRpc?: string,
+  ) {
     // Create parent chain client
     const parentChainInformation = getChainInfoFromChainId(parentChainId);
     this.parentChainPublicClient = createPublicClient({

--- a/examples/verify-rollup/src/lib/utils.ts
+++ b/examples/verify-rollup/src/lib/utils.ts
@@ -35,6 +35,7 @@ import {
   decodeEventLog,
   getAddress,
   trim,
+  pad,
   decodeFunctionData,
   zeroAddress,
 } from 'viem';
@@ -279,7 +280,7 @@ export const getCurrentAdminOfContract = async (
   if (!adminAddress) {
     return getAddress('0x');
   }
-  return getAddress(trim(adminAddress));
+  return getAddress(pad(trim(adminAddress), { size: 20 }));
 };
 
 export const getLogicAddressOfContract = async (

--- a/examples/verify-rollup/src/verify-rollup.ts
+++ b/examples/verify-rollup/src/verify-rollup.ts
@@ -13,6 +13,7 @@ if (!process.env.PARENT_CHAIN_ID || !process.env.ROLLUP_ADDRESS) {
 // Get the orbit handler
 const orbitHandler = new OrbitHandler(
   Number(process.env.PARENT_CHAIN_ID),
+  process.env.PARENT_CHAIN_RPC ?? undefined,
   process.env.ORBIT_CHAIN_ID ? Number(process.env.ORBIT_CHAIN_ID) : undefined,
   process.env.ORBIT_CHAIN_RPC ?? undefined,
 );


### PR DESCRIPTION
When using the public RPC for Sepolia or Ethereum mainnet, the query to search for events might take too long and the request might timeout.
This is a temporary patch that allows a custom RPC to be specified which will perform these searches faster.

The solution to the problem, however, is to somehow restrict the range of blocks to search events on. This patch will allow clients to continue using the verification script in the short term.

This PR also fixes one bug that breaks the script when getting admins of contracts that have leading 0s in them.