### PR TITLE
feat: reduce default finalize distance

### DIFF
--- a/src/prepareNodeConfig.ts
+++ b/src/prepareNodeConfig.ts
@@ -109,6 +109,7 @@ export function prepareNodeConfig({
       'delayed-sequencer': {
         'enable': true,
         'use-merge-finality': false,
+        'finalize-distance': 1,
       },
       'batch-poster': {
         'max-size': 90000,

--- a/src/types/NodeConfig.ts
+++ b/src/types/NodeConfig.ts
@@ -52,6 +52,7 @@ export type NodeConfig = {
     'delayed-sequencer': {
       'enable': boolean;
       'use-merge-finality': boolean;
+      'finalize-distance': number;
     };
     'batch-poster': {
       'max-size': number;


### PR DESCRIPTION
This PR adds one more parameter to the node configuration. Since we are using the fast-deposit configuration parameters, we can reduce the number of blocks the chain waits for finalization to 1 (instead of the default 20).