### PR TITLE
fix: Add yarn install to README + minor format fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ TypeScript SDK for building [Arbitrum Orbit](https://arbitrum.io/orbit) chains.
 Make sure you are using Node v18 or greater.
 
 ```bash
+yarn install
+```
+Then:
+
+```bash
 yarn add @arbitrum/orbit-sdk viem@^1.20.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Make sure you are using Node v18 or greater.
 ```bash
 yarn install
 ```
+
 Then:
 
 ```bash

--- a/examples/create-rollup-custom-fee-token/index.ts
+++ b/examples/create-rollup-custom-fee-token/index.ts
@@ -73,9 +73,8 @@ async function main() {
   };
 
   if (!(await createRollupEnoughCustomFeeTokenAllowance(allowanceParams))) {
-    const approvalTxRequest = await createRollupPrepareCustomFeeTokenApprovalTransactionRequest(
-      allowanceParams,
-    );
+    const approvalTxRequest =
+      await createRollupPrepareCustomFeeTokenApprovalTransactionRequest(allowanceParams);
 
     // sign and send the transaction
     const approvalTxHash = await parentChainPublicClient.sendRawTransaction({

--- a/package.json
+++ b/package.json
@@ -24,9 +24,13 @@
     "dotenv": "^16.3.1",
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0",
-    "prettier": "^2.8.3",
+    "prettier": "2.8.8",
     "ts-morph": "^21.0.1",
     "typescript": "^5.2.2",
     "vitest": "^0.34.6"
+  },
+  "dependencies": {
+    "@arbitrum/orbit-sdk": "^0.8.0",
+    "viem": "^1.20.0"
   }
 }

--- a/src/createTokenBridge-ethers.ts
+++ b/src/createTokenBridge-ethers.ts
@@ -79,9 +79,7 @@ export const createTokenBridgeGetInputs = async (
     wethGateway: await l1Provider.getCode(await l1TokenBridgeCreator.l2WethGatewayTemplate()),
     aeWeth: await l1Provider.getCode(await l1TokenBridgeCreator.l2WethTemplate()),
     upgradeExecutor: await l1Provider.getCode(
-      (
-        await l1TokenBridgeCreator.l1Templates()
-      ).upgradeExecutor,
+      (await l1TokenBridgeCreator.l1Templates()).upgradeExecutor,
     ),
     multicall: await l1Provider.getCode(await l1TokenBridgeCreator.l2MulticallTemplate()),
   };


### PR DESCRIPTION
Running `yarn install` is usually obvious, but since a `yarn add` command follows the invocation, it might be nice to mention it.
