### PR TITLE
fix: allow rollup address override

### DIFF
--- a/src/decorators/rollupAdminLogicActions.unit.test.ts
+++ b/src/decorators/rollupAdminLogicActions.unit.test.ts
@@ -7,15 +7,15 @@ import {
   createPublicClient,
   http,
 } from 'viem';
-import { nitroTestnodeL2 } from '../chains';
 import { rollupAdminLogicPublicActions } from './rollupAdminLogicPublicActions';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { RollupAdminLogic__factory } from '@arbitrum/sdk/dist/lib/abi/factories/RollupAdminLogic__factory';
+import { mainnet } from 'viem/chains';
 
-const rollupAdminLogicAddress = '0x42b5da0625cf278067955f07045f63cafd79274f';
+const rollupAdminLogicAddress = '0x5eF0D09d1E6204141B4d37530808eD19f60FBa35';
 
 const client = createPublicClient({
-  chain: nitroTestnodeL2,
+  chain: mainnet,
   transport: http(),
 }).extend(rollupAdminLogicPublicActions({ rollup: rollupAdminLogicAddress }));
 
@@ -24,7 +24,7 @@ const randomAccount = privateKeyToAccount(generatePrivateKey());
 describe('RollupAdminLogic parameter:', () => {
   it('require rollupAdminLogic parameter if not passed initially to the actions during initialization', () => {
     const clientWithoutRollupAdminLogicAddress = createPublicClient({
-      chain: nitroTestnodeL2,
+      chain: mainnet,
       transport: http(),
     }).extend(rollupAdminLogicPublicActions({}));
 
@@ -45,7 +45,7 @@ describe('RollupAdminLogic parameter:', () => {
 
   it('Doesn`t require rollupAdminLogic parameter if passed initially to the actions during initialization', () => {
     const clientWithRollupAdminLogicAddress = createPublicClient({
-      chain: nitroTestnodeL2,
+      chain: mainnet,
       transport: http(),
     }).extend(rollupAdminLogicPublicActions({ rollup: rollupAdminLogicAddress }));
 
@@ -59,7 +59,7 @@ describe('RollupAdminLogic parameter:', () => {
 
   it('Allow rollupAdminLogic override parameter if passed initially to the actions during initialization', async () => {
     const clientWithRollupAdminLogicAddress = createPublicClient({
-      chain: nitroTestnodeL2,
+      chain: mainnet,
       transport: http(),
     }).extend(rollupAdminLogicPublicActions({ rollup: randomAccount.address }));
 

--- a/src/decorators/rollupAdminLogicActions.unit.test.ts
+++ b/src/decorators/rollupAdminLogicActions.unit.test.ts
@@ -84,6 +84,7 @@ describe('RollupAdminLogic parameter:', () => {
       functionName: 'amountStaked',
       args: [randomAccount.address],
     });
+    readContractSpy.mockClear();
   });
 });
 

--- a/src/decorators/rollupAdminLogicPublicActions.integration.test.ts
+++ b/src/decorators/rollupAdminLogicPublicActions.integration.test.ts
@@ -18,7 +18,6 @@ const client = createPublicClient({
   }),
 );
 
-console.log(l3Rollup);
 it('successfully set validators', async () => {
   const randomAccounts = [
     privateKeyToAccount(generatePrivateKey()).address,

--- a/src/decorators/rollupAdminLogicPublicActions.integration.test.ts
+++ b/src/decorators/rollupAdminLogicPublicActions.integration.test.ts
@@ -18,6 +18,7 @@ const client = createPublicClient({
   }),
 );
 
+console.log(l3Rollup);
 it('successfully set validators', async () => {
   const randomAccounts = [
     privateKeyToAccount(generatePrivateKey()).address,

--- a/src/decorators/rollupAdminLogicPublicActions.ts
+++ b/src/decorators/rollupAdminLogicPublicActions.ts
@@ -59,7 +59,7 @@ export function rollupAdminLogicPublicActions<
       ) => {
         return rollupAdminLogicReadContract(client, {
           ...args,
-          rollup: rollup || args.rollup,
+          rollup: args.rollup || rollup,
         } as RollupAdminLogicReadContractParameters<TFunctionName>);
       },
       rollupAdminLogicPrepareTransactionRequest: <
@@ -69,7 +69,7 @@ export function rollupAdminLogicPublicActions<
       ) => {
         return rollupAdminLogicPrepareTransactionRequest(client, {
           ...args,
-          rollup: rollup || args.rollup,
+          rollup: args.rollup || rollup,
         } as RollupAdminLogicPrepareTransactionRequestParameters<TFunctionName>);
       },
     };


### PR DESCRIPTION
Allow user to pass an address to override the rollup address passed when creating the actions.
Add unit test.

closes FS-514