### PR TITLE
fix: properly type `createRollupPrepareConfig` args

### DIFF
--- a/src/__snapshots__/createRollupPrepareConfig.unit.test.ts.snap
+++ b/src/__snapshots__/createRollupPrepareConfig.unit.test.ts.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`creates config with defaults 1`] = `
+{
+  "baseStake": 100000000000000000n,
+  "chainConfig": "{\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":20,\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\"},\\"chainId\\":69420}",
+  "chainId": 69420n,
+  "confirmPeriodBlocks": 150n,
+  "extraChallengeTimeBlocks": 0n,
+  "genesisBlockNum": 0n,
+  "loserStakeEscrow": "0x0000000000000000000000000000000000000000",
+  "owner": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+  "sequencerInboxMaxTimeVariation": {
+    "delayBlocks": 5760n,
+    "delaySeconds": 86400n,
+    "futureBlocks": 48n,
+    "futureSeconds": 3600n,
+  },
+  "stakeToken": "0x0000000000000000000000000000000000000000",
+  "wasmModuleRoot": "0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4",
+}
+`;
+
+exports[`creates config with overrides 1`] = `
+{
+  "baseStake": 100000000000000000n,
+  "chainConfig": "{\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":true,\\"InitialArbOSVersion\\":30,\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\"},\\"chainId\\":69420}",
+  "chainId": 69420n,
+  "confirmPeriodBlocks": 4200n,
+  "extraChallengeTimeBlocks": 5n,
+  "genesisBlockNum": 0n,
+  "loserStakeEscrow": "0x0000000000000000000000000000000000000001",
+  "owner": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+  "sequencerInboxMaxTimeVariation": {
+    "delayBlocks": 200n,
+    "delaySeconds": 5n,
+    "futureBlocks": 100n,
+    "futureSeconds": 1n,
+  },
+  "stakeToken": "0x0000000000000000000000000000000000000002",
+  "wasmModuleRoot": "0xWasmModuleRoot",
+}
+`;

--- a/src/createRollupPrepareConfig.ts
+++ b/src/createRollupPrepareConfig.ts
@@ -3,15 +3,17 @@ import { parseEther, zeroAddress } from 'viem';
 import { ChainConfig } from './types/ChainConfig';
 import { CreateRollupFunctionInputs } from './types/createRollupTypes';
 import { prepareChainConfig } from './prepareChainConfig';
-
-type RequiredKeys = 'chainId' | 'owner';
+import { Prettify } from './types/utils';
 
 export type CreateRollupPrepareConfigResult = CreateRollupFunctionInputs[0]['config'];
 
-export type CreateRollupPrepareConfigParams = Pick<CreateRollupPrepareConfigResult, RequiredKeys> &
-  Partial<Omit<CreateRollupPrepareConfigResult | 'chainConfig', RequiredKeys>> & {
-    chainConfig?: ChainConfig;
-  };
+type RequiredKeys = 'chainId' | 'owner';
+type RequiredParams = Pick<CreateRollupPrepareConfigResult, RequiredKeys>;
+type OptionalParams = Partial<Omit<CreateRollupPrepareConfigResult, 'chainConfig' | RequiredKeys>>;
+
+export type CreateRollupPrepareConfigParams = Prettify<
+  RequiredParams & { chainConfig?: ChainConfig } & OptionalParams
+>;
 
 const wasmModuleRoot: `0x${string}` =
   // https://github.com/OffchainLabs/nitro/releases/tag/consensus-v20

--- a/src/createRollupPrepareConfig.unit.test.ts
+++ b/src/createRollupPrepareConfig.unit.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from 'vitest';
+
+import { prepareChainConfig } from './prepareChainConfig';
+import { createRollupPrepareConfig } from './createRollupPrepareConfig';
+
+const chainId = 69_420n;
+const vitalik: `0x${string}` = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+
+it('creates config with defaults', () => {
+  expect(
+    createRollupPrepareConfig({
+      owner: vitalik,
+      chainId,
+    }),
+  ).toMatchSnapshot();
+});
+
+it('creates config with overrides', () => {
+  expect(
+    createRollupPrepareConfig({
+      owner: vitalik,
+      chainId,
+      chainConfig: prepareChainConfig({
+        chainId: 69_420,
+        arbitrum: {
+          InitialChainOwner: vitalik,
+          InitialArbOSVersion: 30,
+          DataAvailabilityCommittee: true,
+        },
+      }),
+      confirmPeriodBlocks: 4200n,
+      extraChallengeTimeBlocks: 5n,
+      loserStakeEscrow: '0x0000000000000000000000000000000000000001',
+      sequencerInboxMaxTimeVariation: {
+        delayBlocks: 200n,
+        delaySeconds: 5n,
+        futureBlocks: 100n,
+        futureSeconds: 1n,
+      },
+      stakeToken: '0x0000000000000000000000000000000000000002',
+      wasmModuleRoot: '0xWasmModuleRoot',
+    }),
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
This PR:
- fixes the type for arguments to `createRollupPrepareConfig`

Problem was there was a typo:

```
Partial<Omit<CreateRollupPrepareConfigResult | 'chainConfig', RequiredKeys>>
```

but the correct way is:

```
Partial<Omit<CreateRollupPrepareConfigResult, 'chainConfig' | RequiredKeys>>;
```

- adds tests (will be useful for next set of PRs to make sure we don't break things)

Closes FS-551.