### PR TITLE
feat: update wasm utils as consensus release utils

### DIFF
--- a/src/createRollupPrepareDeploymentParamsConfigDefaults.ts
+++ b/src/createRollupPrepareDeploymentParamsConfigDefaults.ts
@@ -1,12 +1,12 @@
 import { parseEther, zeroAddress } from 'viem';
 
-import { getWasmModuleRoot } from './wasmModuleRoot';
+import { getConsensusReleaseByVersion } from './wasmModuleRoot';
 
 export const defaults = {
   extraChallengeTimeBlocks: BigInt(0),
   stakeToken: zeroAddress,
   baseStake: parseEther(String(0.1)),
-  wasmModuleRoot: getWasmModuleRoot(31),
+  wasmModuleRoot: getConsensusReleaseByVersion(31).wasmModuleRoot,
   loserStakeEscrow: zeroAddress,
   genesisBlockNum: BigInt(0),
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,12 +126,12 @@ import {
 } from './setAnyTrustFastConfirmerPrepareTransactionRequest';
 import {
   ConsensusVersion,
+  getConsensusReleaseByVersion,
+  GetConsensusReleaseByVersion,
   WasmModuleRoot,
-  GetWasmModuleRoot,
-  getWasmModuleRoot,
   isKnownWasmModuleRoot,
-  GetConsensusVersion,
-  getConsensusVersion,
+  getConsensusReleaseByWasmModuleRoot,
+  GetConsensusReleaseByWasmModuleRoot,
 } from './wasmModuleRoot';
 
 export {
@@ -239,10 +239,10 @@ export {
   SetAnyTrustFastConfirmerPrepareTransactionRequestParams,
   //
   ConsensusVersion,
+  getConsensusReleaseByVersion,
+  GetConsensusReleaseByVersion,
   WasmModuleRoot,
-  GetWasmModuleRoot,
-  getWasmModuleRoot,
   isKnownWasmModuleRoot,
-  GetConsensusVersion,
-  getConsensusVersion,
+  getConsensusReleaseByWasmModuleRoot,
+  GetConsensusReleaseByWasmModuleRoot,
 };

--- a/src/wasmModuleRoot.ts
+++ b/src/wasmModuleRoot.ts
@@ -1,6 +1,6 @@
 import { Hex } from 'viem';
 
-export type ConsensusRelease = {
+type ConsensusRelease = {
   version: number;
   wasmModuleRoot: Hex;
 };
@@ -58,19 +58,34 @@ type ConsensusReleases = typeof consensusReleases;
 export type ConsensusVersion = ConsensusReleases[number]['version'];
 export type WasmModuleRoot = ConsensusReleases[number]['wasmModuleRoot'];
 
-export type GetWasmModuleRoot<TConsensusVersion extends ConsensusVersion> = Extract<
+export type GetConsensusReleaseByVersion<TConsensusVersion extends ConsensusVersion> = Extract<
   ConsensusReleases[number],
   { version: TConsensusVersion }
->['wasmModuleRoot'];
+>;
 
-export function getWasmModuleRoot<TConsensusVersion extends ConsensusVersion>(
+export function getConsensusReleaseByVersion<TConsensusVersion extends ConsensusVersion>(
   consensusVersion: TConsensusVersion,
-): GetWasmModuleRoot<TConsensusVersion> {
-  const wasmModuleRoot = consensusReleases
+): GetConsensusReleaseByVersion<TConsensusVersion> {
+  const consensusRelease = consensusReleases
     //
-    .find((release) => release.version === consensusVersion)!.wasmModuleRoot;
+    .find((release) => release.version === consensusVersion)!;
 
-  return wasmModuleRoot as GetWasmModuleRoot<TConsensusVersion>;
+  return consensusRelease as GetConsensusReleaseByVersion<TConsensusVersion>;
+}
+
+export type GetConsensusReleaseByWasmModuleRoot<TWasmModuleRoot extends WasmModuleRoot> = Extract<
+  ConsensusReleases[number],
+  { wasmModuleRoot: TWasmModuleRoot }
+>;
+
+export function getConsensusReleaseByWasmModuleRoot<TWasmModuleRoot extends WasmModuleRoot>(
+  wasmModuleRoot: TWasmModuleRoot,
+): GetConsensusReleaseByWasmModuleRoot<TWasmModuleRoot> {
+  const consensusRelease = consensusReleases
+    //
+    .find((release) => release.wasmModuleRoot === wasmModuleRoot)!;
+
+  return consensusRelease as GetConsensusReleaseByWasmModuleRoot<TWasmModuleRoot>;
 }
 
 export function isKnownWasmModuleRoot(wasmModuleRoot: Hex): wasmModuleRoot is WasmModuleRoot {
@@ -79,19 +94,4 @@ export function isKnownWasmModuleRoot(wasmModuleRoot: Hex): wasmModuleRoot is Wa
       //
       .includes(wasmModuleRoot)
   );
-}
-
-export type GetConsensusVersion<TWasmModuleRoot extends WasmModuleRoot> = Extract<
-  ConsensusReleases[number],
-  { wasmModuleRoot: TWasmModuleRoot }
->['version'];
-
-export function getConsensusVersion<TWasmModuleRoot extends WasmModuleRoot>(
-  wasmModuleRoot: TWasmModuleRoot,
-): GetConsensusVersion<TWasmModuleRoot> {
-  const consensusVersion = consensusReleases
-    //
-    .find((release) => release.wasmModuleRoot === wasmModuleRoot)!.version;
-
-  return consensusVersion as GetConsensusVersion<TWasmModuleRoot>;
 }

--- a/src/wasmModuleRoot.ts
+++ b/src/wasmModuleRoot.ts
@@ -68,7 +68,7 @@ export function getConsensusReleaseByVersion<TConsensusVersion extends Consensus
 ): GetConsensusReleaseByVersion<TConsensusVersion> {
   const consensusRelease = consensusReleases
     //
-    .find((release) => release.version === consensusVersion)!;
+    .find((release) => release.version === consensusVersion);
 
   return consensusRelease as GetConsensusReleaseByVersion<TConsensusVersion>;
 }
@@ -83,7 +83,7 @@ export function getConsensusReleaseByWasmModuleRoot<TWasmModuleRoot extends Wasm
 ): GetConsensusReleaseByWasmModuleRoot<TWasmModuleRoot> {
   const consensusRelease = consensusReleases
     //
-    .find((release) => release.wasmModuleRoot === wasmModuleRoot)!;
+    .find((release) => release.wasmModuleRoot === wasmModuleRoot);
 
   return consensusRelease as GetConsensusReleaseByWasmModuleRoot<TWasmModuleRoot>;
 }


### PR DESCRIPTION
The original approach made sense when the only info on the consensus release was `wasmModuleRoot`. In a future PR, I'll be adding `maxSupportedArbOSVersion` to each consensus release for extra validation, so having utils to return the whole object instead of just a single property makes more sense for future-proofing.