### PR TITLE
fix: add fastConfirmer to the validator list

### DIFF
--- a/examples/setup-fast-withdrawal/index.ts
+++ b/examples/setup-fast-withdrawal/index.ts
@@ -143,6 +143,10 @@ async function main() {
   );
   console.log('');
 
+  // add the new Safe address as a validator
+  // (needed to call removeOldZombies() as part of the fastConfirmNextNode() flow)
+  fcValidators.push(safeAddress);
+
   //
   // Step 2. Add validators to the Orbit chain rollup validator whitelist
   //
@@ -297,13 +301,13 @@ async function main() {
 
   // Batch poster configuration
   const timeDelay = getTimeDelayFromNumberOfBlocks(parentChain.id, minimumAssertionPeriod);
-  console.log('Your batch poster has to run at least nitro v3.x');
+  console.log('Your batch poster has to run at least nitro v3.1.1');
   console.log('Add the following parameter:');
   console.log(`--node.batch-poster.max-delay=${timeDelay}`);
   console.log('');
 
   // Validator configuration
-  console.log('Your validators have to run at least nitro v3.x');
+  console.log('Your validators have to run at least nitro v3.1.1');
   console.log('Add the following parameters:');
   console.log(`--node.staker.enable-fast-confirmation=true`);
   console.log(`--node.staker.fast-confirm-safe-address=${safeAddress}`);


### PR DESCRIPTION
When running the setup-fast-withdrawal script, the fastConfirmer is not added to the validator whitelist, and thus can't fastConfirm any node (the caller needs to be a validator too).

This PR fixes that.