### PR TITLE
fix: use proper router for ChildToParentRewardRouter

### DIFF
--- a/examples/setup-aep-fee-router/index.ts
+++ b/examples/setup-aep-fee-router/index.ts
@@ -15,6 +15,7 @@ import {
   arbOwnerPublicActions,
   arbGasInfoPublicActions,
   parentChainIsArbitrum,
+  ParentChainId,
 } from '@arbitrum/orbit-sdk';
 import { sanitizePrivateKey, getParentChainFromId } from '@arbitrum/orbit-sdk/utils';
 import { config } from 'dotenv';
@@ -74,7 +75,7 @@ const parentChainTargetAddress = getAddress(process.env.PARENT_CHAIN_TARGET_ADDR
 
 async function main() {
   // Verify that this is an orbit chain settling to a non-Arbitrum chain
-  if (parentChainIsArbitrum(parentChainPublicClient.chain.id)) {
+  if (parentChainIsArbitrum(parentChainPublicClient.chain.id as ParentChainId)) {
     throw new Error(
       'This script is intended to be used only by Orbit chains settling to non Arbitrum chains.',
     );

--- a/src/feeRouterDeployChildToParentRewardRouter.ts
+++ b/src/feeRouterDeployChildToParentRewardRouter.ts
@@ -123,7 +123,7 @@ export async function feeRouterDeployChildToParentRewardRouter<TChain extends Ch
     // obtain the token address in the Orbit chain
     // (we can use either gateway router to obtain the "L2 token address")
     const orbitChainTokenAddress = await parentChainPublicClient.readContract({
-      address: orbitChainGatewayRouter,
+      address: tokenBridgeContracts.parentChainContracts.router,
       abi: parseAbi(['function calculateL2TokenAddress(address) view returns (address)']),
       functionName: 'calculateL2TokenAddress',
       args: [parentChainTokenAddress],


### PR DESCRIPTION
This PR fixes a small bug where the function feeRouterDeployChildToParentRewardRouter uses the wrong router based on the client used. Since it makes more sense to use the parent chain client, the parent chain router is used now.