### PR TITLE
fix: handle unknown Safe call in getValidators

### DIFF
--- a/src/getValidators.ts
+++ b/src/getValidators.ts
@@ -170,10 +170,23 @@ export async function getValidators<TChain extends Chain>(
           abi: [execTransactionABI],
           data: tx.input,
         });
+
+        const execTransactionCalldataData = execTransactionCalldata[2];
+        const execTransactionCalldataDataFnSelector = execTransactionCalldataData.slice(0, 10);
+
+        if (execTransactionCalldataDataFnSelector !== upgradeExecutorExecuteCallFunctionSelector) {
+          console.warn(
+            `[getValidators] unable to decode "execTransaction" calldata, tx id: ${tx.hash}`,
+          );
+          isAccurate = false;
+          return acc;
+        }
+
         const { args: executeCallCalldata } = decodeFunctionData({
           abi: [executeCallABI],
-          data: execTransactionCalldata[2],
+          data: execTransactionCalldataData,
         });
+
         return updateAccumulator(acc, executeCallCalldata[1]);
       }
       default: {

--- a/src/getValidators.unit.test.ts
+++ b/src/getValidators.unit.test.ts
@@ -151,7 +151,7 @@ it('getValidators return all validators (Xai)', async () => {
     rollup: '0xc47dacfbaa80bd9d8112f4e8069482c2a3221336',
   });
   expect(validators).toEqual(['0x25EA41f0bDa921a0eBf48291961B1F10b59BC6b8']);
-  expect(isAccurate).toBeTruthy();
+  expect(isAccurate).toBeFalsy();
 });
 
 // https://sepolia.arbiscan.io/tx/0x5b0b49e0259289fc89949a55a5ad35a8939440a55065d29b14e5e7ef7494efff


### PR DESCRIPTION
Looks like the Xai team used [MultiSend](https://github.com/safe-global/safe-smart-account/blob/main/contracts/libraries/MultiSend.sol) to do multiple calls to the UpgradeExecutor in a single transaction.
We currently don't support decoding MultiSend calls, so it was throwing an error.

For now, I handled it so we explicitly only support inner call directly to UpgradeExecutor, and I'll track supporting other signatures in another ticket.