### PR TITLE
build(deps): bump elliptic from 6.5.7 to 6.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "resolutions": {
     "**/@wagmi/cli/viem/ws": "8.17.1",
     "**/@ethersproject/providers/ws": "7.5.10",
-    "**/elliptic": "6.5.7",
+    "**/elliptic": "6.6.1",
     "**/nanoid": "3.3.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,10 +1596,10 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-elliptic@6.5.4, elliptic@6.5.7, elliptic@^6.5.4:
-  version "6.5.7"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
-  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
+elliptic@6.5.4, elliptic@6.6.1, elliptic@^6.5.4:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
Resolves this advisory https://github.com/advisories/GHSA-vjh7-7g9h-fjfh