### PR TITLE
[Test] Testnode with predeploys

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@feat-simplify
         with:
-          nitro-testnode-ref: release
+          nitro-testnode-ref: cb81aef3d596a22c6b1a9196f921f279fa81044f
           nitro-contracts-branch: ${{ matrix.config.nitro-contracts-branch }}
           args: ${{ matrix.config.args }}
 

--- a/token-bridge-contracts/Dockerfile
+++ b/token-bridge-contracts/Dockerfile
@@ -2,7 +2,8 @@ FROM node:20-bullseye-slim
 RUN apt-get update && \
     apt-get install -y git docker.io python3 chromium build-essential
 WORKDIR /workspace
-RUN git clone -b v1.2.2 https://github.com/OffchainLabs/token-bridge-contracts.git ./
+RUN git clone https://github.com/OffchainLabs/token-bridge-contracts.git ./
+RUN git checkout e222d4cdaeefc87773e39a5fce980667a80b886b
 RUN yarn install
 RUN yarn build
 ENTRYPOINT ["yarn"]


### PR DESCRIPTION
DO NOT MERGE

This is just a test to check that the predeployed contracts in the testnode work as intended

A bunch of tests fail:
- TokenBridge tests: it looks like these fail because the tests don't expect that no new TokenBridgeCreators are deployed, so when trying to create a new token bridge for a specific rollup, it already exists in the canonical TokenBridgeCreator, and the test fails.
- UpgradeExecutor: not sure what could be wrong with these, would have to dig deeper.