### PR TITLE
feat(scripting): add zod schemas for action functions

### DIFF
--- a/src/scripting/schemas/actions/buildInvalidateKeysetHash.ts
+++ b/src/scripting/schemas/actions/buildInvalidateKeysetHash.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { toPublicClient, toAccount, findChain } from '../../viemTransforms';
+import { addressSchema, hexSchema, privateKeySchema } from '../common';
+import { buildInvalidateKeysetHash } from '../../../actions/buildInvalidateKeysetHash';
+
+export const buildInvalidateKeysetHashSchema = z.strictObject({
+  rpcUrl: z.url(),
+  chainId: z.number(),
+  privateKey: privateKeySchema,
+  upgradeExecutor: addressSchema.optional(),
+  sequencerInbox: addressSchema,
+  keysetHash: hexSchema,
+});
+
+export const buildInvalidateKeysetHashTransform = (
+  input: z.output<typeof buildInvalidateKeysetHashSchema>,
+): Parameters<typeof buildInvalidateKeysetHash> => [
+  toPublicClient(input.rpcUrl, findChain(input.chainId)),
+  {
+    account: toAccount(input.privateKey).address,
+    upgradeExecutor: input.upgradeExecutor ?? false,
+    sequencerInbox: input.sequencerInbox,
+    params: { keysetHash: input.keysetHash },
+  },
+];

--- a/src/scripting/schemas/actions/buildScheduleArbOSUpgrade.ts
+++ b/src/scripting/schemas/actions/buildScheduleArbOSUpgrade.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { toPublicClient, toAccount, findChain } from '../../viemTransforms';
+import { addressSchema, bigintSchema, privateKeySchema, gasOptionsSchema } from '../common';
+import { buildScheduleArbOSUpgrade } from '../../../actions/buildScheduleArbOSUpgrade';
+
+export const buildScheduleArbOSUpgradeSchema = z.strictObject({
+  rpcUrl: z.url(),
+  chainId: z.number(),
+  privateKey: privateKeySchema,
+  upgradeExecutor: addressSchema.optional(),
+  newVersion: bigintSchema,
+  timestamp: bigintSchema,
+  gasOverrides: z
+    .object({
+      gasLimit: gasOptionsSchema.optional(),
+    })
+    .optional(),
+});
+
+export const buildScheduleArbOSUpgradeTransform = (
+  input: z.output<typeof buildScheduleArbOSUpgradeSchema>,
+): Parameters<typeof buildScheduleArbOSUpgrade> => [
+  toPublicClient(input.rpcUrl, findChain(input.chainId)),
+  {
+    account: toAccount(input.privateKey).address,
+    upgradeExecutor: input.upgradeExecutor ?? false,
+    args: [input.newVersion, input.timestamp],
+    ...(input.gasOverrides && { gasOverrides: input.gasOverrides }),
+  },
+];

--- a/src/scripting/schemas/actions/buildSetIsBatchPoster.ts
+++ b/src/scripting/schemas/actions/buildSetIsBatchPoster.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { toPublicClient, toAccount, findChain } from '../../viemTransforms';
+import { addressSchema, privateKeySchema } from '../common';
+import { buildSetIsBatchPoster } from '../../../actions/buildSetIsBatchPoster';
+
+export const buildSetIsBatchPosterSchema = z.strictObject({
+  rpcUrl: z.url(),
+  chainId: z.number(),
+  privateKey: privateKeySchema,
+  upgradeExecutor: addressSchema.optional(),
+  sequencerInbox: addressSchema,
+  batchPoster: addressSchema,
+  enable: z.boolean(),
+});
+
+export const buildSetIsBatchPosterTransform = (
+  input: z.output<typeof buildSetIsBatchPosterSchema>,
+): Parameters<typeof buildSetIsBatchPoster> => [
+  toPublicClient(input.rpcUrl, findChain(input.chainId)),
+  {
+    account: toAccount(input.privateKey).address,
+    upgradeExecutor: input.upgradeExecutor ?? false,
+    sequencerInbox: input.sequencerInbox,
+    params: { batchPoster: input.batchPoster, enable: input.enable },
+  },
+];

--- a/src/scripting/schemas/actions/buildSetMaxTimeVariation.ts
+++ b/src/scripting/schemas/actions/buildSetMaxTimeVariation.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod';
 import { toPublicClient, toAccount, findChain } from '../../viemTransforms';
-import {
-  addressSchema,
-  privateKeySchema,
-  sequencerInboxMaxTimeVariationSchema,
-} from '../common';
+import { addressSchema, privateKeySchema, sequencerInboxMaxTimeVariationSchema } from '../common';
 import { buildSetMaxTimeVariation } from '../../../actions/buildSetMaxTimeVariation';
 
 export const buildSetMaxTimeVariationSchema = z.strictObject({

--- a/src/scripting/schemas/actions/buildSetMaxTimeVariation.ts
+++ b/src/scripting/schemas/actions/buildSetMaxTimeVariation.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { toPublicClient, toAccount, findChain } from '../../viemTransforms';
+import {
+  addressSchema,
+  privateKeySchema,
+  sequencerInboxMaxTimeVariationSchema,
+} from '../common';
+import { buildSetMaxTimeVariation } from '../../../actions/buildSetMaxTimeVariation';
+
+export const buildSetMaxTimeVariationSchema = z.strictObject({
+  rpcUrl: z.url(),
+  chainId: z.number(),
+  privateKey: privateKeySchema,
+  upgradeExecutor: addressSchema.optional(),
+  sequencerInbox: addressSchema,
+  ...sequencerInboxMaxTimeVariationSchema.shape,
+});
+
+export const buildSetMaxTimeVariationTransform = (
+  input: z.output<typeof buildSetMaxTimeVariationSchema>,
+): Parameters<typeof buildSetMaxTimeVariation> => [
+  toPublicClient(input.rpcUrl, findChain(input.chainId)),
+  {
+    account: toAccount(input.privateKey).address,
+    upgradeExecutor: input.upgradeExecutor ?? false,
+    sequencerInbox: input.sequencerInbox,
+    params: {
+      delayBlocks: input.delayBlocks,
+      futureBlocks: input.futureBlocks,
+      delaySeconds: input.delaySeconds,
+      futureSeconds: input.futureSeconds,
+    },
+  },
+];

--- a/src/scripting/schemas/actions/buildSetValidKeyset.ts
+++ b/src/scripting/schemas/actions/buildSetValidKeyset.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { toPublicClient, toAccount, findChain } from '../../viemTransforms';
+import { addressSchema, hexSchema, privateKeySchema } from '../common';
+import { buildSetValidKeyset } from '../../../actions/buildSetValidKeyset';
+
+export const buildSetValidKeysetSchema = z.strictObject({
+  rpcUrl: z.url(),
+  chainId: z.number(),
+  privateKey: privateKeySchema,
+  upgradeExecutor: addressSchema.optional(),
+  sequencerInbox: addressSchema,
+  keyset: hexSchema,
+});
+
+export const buildSetValidKeysetTransform = (
+  input: z.output<typeof buildSetValidKeysetSchema>,
+): Parameters<typeof buildSetValidKeyset> => [
+  toPublicClient(input.rpcUrl, findChain(input.chainId)),
+  {
+    account: toAccount(input.privateKey).address,
+    upgradeExecutor: input.upgradeExecutor ?? false,
+    sequencerInbox: input.sequencerInbox,
+    params: { keyset: input.keyset },
+  },
+];

--- a/src/scripting/schemas/actions/getMaxTimeVariation.ts
+++ b/src/scripting/schemas/actions/getMaxTimeVariation.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { toPublicClient, findChain } from '../../viemTransforms';
+import { addressSchema } from '../common';
+import { getMaxTimeVariation } from '../../../actions/getMaxTimeVariation';
+
+export const getMaxTimeVariationSchema = z.strictObject({
+  rpcUrl: z.url(),
+  chainId: z.number(),
+  sequencerInbox: addressSchema,
+});
+
+export const getMaxTimeVariationTransform = (
+  input: z.output<typeof getMaxTimeVariationSchema>,
+): Parameters<typeof getMaxTimeVariation> => [
+  toPublicClient(input.rpcUrl, findChain(input.chainId)),
+  {
+    sequencerInbox: input.sequencerInbox,
+  },
+];

--- a/src/scripting/schemas/actions/index.ts
+++ b/src/scripting/schemas/actions/index.ts
@@ -2,10 +2,7 @@ export {
   buildSetIsBatchPosterSchema,
   buildSetIsBatchPosterTransform,
 } from './buildSetIsBatchPoster';
-export {
-  buildSetValidKeysetSchema,
-  buildSetValidKeysetTransform,
-} from './buildSetValidKeyset';
+export { buildSetValidKeysetSchema, buildSetValidKeysetTransform } from './buildSetValidKeyset';
 export {
   buildInvalidateKeysetHashSchema,
   buildInvalidateKeysetHashTransform,

--- a/src/scripting/schemas/actions/index.ts
+++ b/src/scripting/schemas/actions/index.ts
@@ -1,0 +1,23 @@
+export {
+  buildSetIsBatchPosterSchema,
+  buildSetIsBatchPosterTransform,
+} from './buildSetIsBatchPoster';
+export {
+  buildSetValidKeysetSchema,
+  buildSetValidKeysetTransform,
+} from './buildSetValidKeyset';
+export {
+  buildInvalidateKeysetHashSchema,
+  buildInvalidateKeysetHashTransform,
+} from './buildInvalidateKeysetHash';
+export {
+  buildSetMaxTimeVariationSchema,
+  buildSetMaxTimeVariationTransform,
+} from './buildSetMaxTimeVariation';
+export {
+  buildScheduleArbOSUpgradeSchema,
+  buildScheduleArbOSUpgradeTransform,
+} from './buildScheduleArbOSUpgrade';
+export { isBatchPosterSchema, isBatchPosterTransform } from './isBatchPoster';
+export { isValidKeysetHashSchema, isValidKeysetHashTransform } from './isValidKeysetHash';
+export { getMaxTimeVariationSchema, getMaxTimeVariationTransform } from './getMaxTimeVariation';

--- a/src/scripting/schemas/actions/isBatchPoster.ts
+++ b/src/scripting/schemas/actions/isBatchPoster.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { toPublicClient, findChain } from '../../viemTransforms';
+import { addressSchema } from '../common';
+import { isBatchPoster } from '../../../actions/isBatchPoster';
+
+export const isBatchPosterSchema = z.strictObject({
+  rpcUrl: z.url(),
+  chainId: z.number(),
+  sequencerInbox: addressSchema,
+  batchPoster: addressSchema,
+});
+
+export const isBatchPosterTransform = (
+  input: z.output<typeof isBatchPosterSchema>,
+): Parameters<typeof isBatchPoster> => [
+  toPublicClient(input.rpcUrl, findChain(input.chainId)),
+  {
+    sequencerInbox: input.sequencerInbox,
+    params: { batchPoster: input.batchPoster },
+  },
+];

--- a/src/scripting/schemas/actions/isValidKeysetHash.ts
+++ b/src/scripting/schemas/actions/isValidKeysetHash.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { toPublicClient, findChain } from '../../viemTransforms';
+import { addressSchema, hexSchema } from '../common';
+import { isValidKeysetHash } from '../../../actions/isValidKeysetHash';
+
+export const isValidKeysetHashSchema = z.strictObject({
+  rpcUrl: z.url(),
+  chainId: z.number(),
+  sequencerInbox: addressSchema,
+  keysetHash: hexSchema,
+});
+
+export const isValidKeysetHashTransform = (
+  input: z.output<typeof isValidKeysetHashSchema>,
+): Parameters<typeof isValidKeysetHash> => [
+  toPublicClient(input.rpcUrl, findChain(input.chainId)),
+  {
+    sequencerInbox: input.sequencerInbox,
+    params: { keysetHash: input.keysetHash },
+  },
+];

--- a/src/scripting/schemas/createRollupPrepareDeploymentParamsConfigDefaults.ts
+++ b/src/scripting/schemas/createRollupPrepareDeploymentParamsConfigDefaults.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import { rollupCreatorVersionSchema } from './common';
+import { RollupCreatorSupportedVersion } from '../../types/createRollupTypes';
+
+export const createRollupPrepareDeploymentParamsConfigDefaultsSchema = z.strictObject({
+  rollupCreatorVersion: rollupCreatorVersionSchema.optional(),
+});
+
+export const createRollupPrepareDeploymentParamsConfigDefaultsTransform = (
+  input: z.output<typeof createRollupPrepareDeploymentParamsConfigDefaultsSchema>,
+): [RollupCreatorSupportedVersion] | [] =>
+  input.rollupCreatorVersion ? [input.rollupCreatorVersion] : [];

--- a/src/scripting/schemas/index.ts
+++ b/src/scripting/schemas/index.ts
@@ -100,3 +100,21 @@ export {
   prepareDeploymentParamsConfigV21Transform,
   prepareDeploymentParamsConfigV32Transform,
 } from './createRollupPrepareDeploymentParamsConfig';
+export {
+  buildSetIsBatchPosterSchema,
+  buildSetIsBatchPosterTransform,
+  buildSetValidKeysetSchema,
+  buildSetValidKeysetTransform,
+  buildInvalidateKeysetHashSchema,
+  buildInvalidateKeysetHashTransform,
+  buildSetMaxTimeVariationSchema,
+  buildSetMaxTimeVariationTransform,
+  buildScheduleArbOSUpgradeSchema,
+  buildScheduleArbOSUpgradeTransform,
+  isBatchPosterSchema,
+  isBatchPosterTransform,
+  isValidKeysetHashSchema,
+  isValidKeysetHashTransform,
+  getMaxTimeVariationSchema,
+  getMaxTimeVariationTransform,
+} from './actions';

--- a/src/scripting/schemas/index.ts
+++ b/src/scripting/schemas/index.ts
@@ -101,6 +101,22 @@ export {
   prepareDeploymentParamsConfigV32Transform,
 } from './createRollupPrepareDeploymentParamsConfig';
 export {
+  createRollupPrepareDeploymentParamsConfigDefaultsSchema,
+  createRollupPrepareDeploymentParamsConfigDefaultsTransform,
+} from './createRollupPrepareDeploymentParamsConfigDefaults';
+export {
+  parentChainIsArbitrumSchema,
+  parentChainIsArbitrumTransform,
+} from './parentChainIsArbitrum';
+export {
+  getConsensusReleaseByVersionSchema,
+  getConsensusReleaseByVersionTransform,
+  getConsensusReleaseByWasmModuleRootSchema,
+  getConsensusReleaseByWasmModuleRootTransform,
+  isKnownWasmModuleRootSchema,
+  isKnownWasmModuleRootTransform,
+} from './wasmModuleRoot';
+export {
   buildSetIsBatchPosterSchema,
   buildSetIsBatchPosterTransform,
   buildSetValidKeysetSchema,

--- a/src/scripting/schemas/parentChainIsArbitrum.ts
+++ b/src/scripting/schemas/parentChainIsArbitrum.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { ParentChainId } from '../../types/ParentChain';
+
+export const parentChainIsArbitrumSchema = z.strictObject({
+  parentChainId: z.number(),
+});
+
+export const parentChainIsArbitrumTransform = (
+  input: z.output<typeof parentChainIsArbitrumSchema>,
+): [ParentChainId] => [input.parentChainId as ParentChainId];

--- a/src/scripting/schemas/schemas.type.test.ts
+++ b/src/scripting/schemas/schemas.type.test.ts
@@ -93,6 +93,18 @@ import { getDefaultsTransform } from './getDefaults';
 import { createRollupGetRetryablesFeesTransform } from './createRollupGetRetryablesFees';
 import { fetchAllowanceTransform, fetchDecimalsTransform } from './erc20';
 import { coreContractsSchema, chainConfigSchema } from './common';
+import { parentChainIsArbitrumTransform } from './parentChainIsArbitrum';
+import { parentChainIsArbitrum } from '../../parentChainIsArbitrum';
+import {
+  getConsensusReleaseByVersion,
+  getConsensusReleaseByWasmModuleRoot,
+  isKnownWasmModuleRoot,
+} from '../../wasmModuleRoot';
+import {
+  getConsensusReleaseByVersionTransform,
+  getConsensusReleaseByWasmModuleRootTransform,
+  isKnownWasmModuleRootTransform,
+} from './wasmModuleRoot';
 import {
   buildSetIsBatchPosterTransform,
   buildSetValidKeysetTransform,
@@ -495,4 +507,24 @@ it('isValidKeysetHashTransform output matches isValidKeysetHash params', () =>
 it('getMaxTimeVariationTransform output matches getMaxTimeVariation params', () =>
   expectTypeOf<DeepNormalize<ReturnType<typeof getMaxTimeVariationTransform>>>().toEqualTypeOf<
     DeepNormalize<Parameters<typeof getMaxTimeVariation>>
+  >());
+
+it('parentChainIsArbitrumTransform output matches parentChainIsArbitrum params', () =>
+  expectTypeOf<DeepNormalize<ReturnType<typeof parentChainIsArbitrumTransform>>>().toEqualTypeOf<
+    DeepNormalize<Parameters<typeof parentChainIsArbitrum>>
+  >());
+
+it('getConsensusReleaseByVersionTransform output matches getConsensusReleaseByVersion params', () =>
+  expectTypeOf<
+    DeepNormalize<ReturnType<typeof getConsensusReleaseByVersionTransform>>
+  >().toEqualTypeOf<DeepNormalize<Parameters<typeof getConsensusReleaseByVersion>>>());
+
+it('getConsensusReleaseByWasmModuleRootTransform output matches getConsensusReleaseByWasmModuleRoot params', () =>
+  expectTypeOf<
+    DeepNormalize<ReturnType<typeof getConsensusReleaseByWasmModuleRootTransform>>
+  >().toEqualTypeOf<DeepNormalize<Parameters<typeof getConsensusReleaseByWasmModuleRoot>>>());
+
+it('isKnownWasmModuleRootTransform output matches isKnownWasmModuleRoot params', () =>
+  expectTypeOf<DeepNormalize<ReturnType<typeof isKnownWasmModuleRootTransform>>>().toEqualTypeOf<
+    DeepNormalize<Parameters<typeof isKnownWasmModuleRoot>>
   >());

--- a/src/scripting/schemas/schemas.type.test.ts
+++ b/src/scripting/schemas/schemas.type.test.ts
@@ -41,6 +41,15 @@ import { CreateRollupPrepareDeploymentParamsConfigParams } from '../../createRol
 import { prepareChainConfig } from '../../prepareChainConfig';
 import { upgradeExecutorPrepareAddExecutorTransactionRequest } from '../../upgradeExecutorPrepareAddExecutorTransactionRequest';
 
+import { buildSetIsBatchPoster } from '../../actions/buildSetIsBatchPoster';
+import { buildSetValidKeyset } from '../../actions/buildSetValidKeyset';
+import { buildInvalidateKeysetHash } from '../../actions/buildInvalidateKeysetHash';
+import { buildSetMaxTimeVariation } from '../../actions/buildSetMaxTimeVariation';
+import { buildScheduleArbOSUpgrade } from '../../actions/buildScheduleArbOSUpgrade';
+import { isBatchPoster } from '../../actions/isBatchPoster';
+import { isValidKeysetHash } from '../../actions/isValidKeysetHash';
+import { getMaxTimeVariation } from '../../actions/getMaxTimeVariation';
+
 import { createRollupTransformedSchema } from './createRollup';
 import { setValidKeysetTransform } from './setValidKeyset';
 import { createTokenBridgeTransform } from './createTokenBridge';
@@ -84,6 +93,16 @@ import { getDefaultsTransform } from './getDefaults';
 import { createRollupGetRetryablesFeesTransform } from './createRollupGetRetryablesFees';
 import { fetchAllowanceTransform, fetchDecimalsTransform } from './erc20';
 import { coreContractsSchema, chainConfigSchema } from './common';
+import {
+  buildSetIsBatchPosterTransform,
+  buildSetValidKeysetTransform,
+  buildInvalidateKeysetHashTransform,
+  buildSetMaxTimeVariationTransform,
+  buildScheduleArbOSUpgradeTransform,
+  isBatchPosterTransform,
+  isValidKeysetHashTransform,
+  getMaxTimeVariationTransform,
+} from './actions';
 
 // DeepNormalize<T>
 //
@@ -436,4 +455,44 @@ it('fetchAllowanceTransform output matches fetchAllowance params', () =>
 it('fetchDecimalsTransform output matches fetchDecimals params', () =>
   expectTypeOf<DeepNormalize<ReturnType<typeof fetchDecimalsTransform>>>().toEqualTypeOf<
     DeepNormalize<Parameters<typeof fetchDecimals>>
+  >());
+
+it('buildSetIsBatchPosterTransform output matches buildSetIsBatchPoster params', () =>
+  expectTypeOf<DeepNormalize<ReturnType<typeof buildSetIsBatchPosterTransform>>>().toEqualTypeOf<
+    DeepNormalize<Parameters<typeof buildSetIsBatchPoster>>
+  >());
+
+it('buildSetValidKeysetTransform output matches buildSetValidKeyset params', () =>
+  expectTypeOf<DeepNormalize<ReturnType<typeof buildSetValidKeysetTransform>>>().toEqualTypeOf<
+    DeepNormalize<Parameters<typeof buildSetValidKeyset>>
+  >());
+
+it('buildInvalidateKeysetHashTransform output matches buildInvalidateKeysetHash params', () =>
+  expectTypeOf<
+    DeepNormalize<ReturnType<typeof buildInvalidateKeysetHashTransform>>
+  >().toEqualTypeOf<DeepNormalize<Parameters<typeof buildInvalidateKeysetHash>>>());
+
+it('buildSetMaxTimeVariationTransform output matches buildSetMaxTimeVariation params', () =>
+  expectTypeOf<
+    DeepNormalize<ReturnType<typeof buildSetMaxTimeVariationTransform>>
+  >().toEqualTypeOf<DeepNormalize<Parameters<typeof buildSetMaxTimeVariation>>>());
+
+it('buildScheduleArbOSUpgradeTransform output matches buildScheduleArbOSUpgrade params', () =>
+  expectTypeOf<
+    DeepNormalize<ReturnType<typeof buildScheduleArbOSUpgradeTransform>>
+  >().toEqualTypeOf<DeepNormalize<Parameters<typeof buildScheduleArbOSUpgrade>>>());
+
+it('isBatchPosterTransform output matches isBatchPoster params', () =>
+  expectTypeOf<DeepNormalize<ReturnType<typeof isBatchPosterTransform>>>().toEqualTypeOf<
+    DeepNormalize<Parameters<typeof isBatchPoster>>
+  >());
+
+it('isValidKeysetHashTransform output matches isValidKeysetHash params', () =>
+  expectTypeOf<DeepNormalize<ReturnType<typeof isValidKeysetHashTransform>>>().toEqualTypeOf<
+    DeepNormalize<Parameters<typeof isValidKeysetHash>>
+  >());
+
+it('getMaxTimeVariationTransform output matches getMaxTimeVariation params', () =>
+  expectTypeOf<DeepNormalize<ReturnType<typeof getMaxTimeVariationTransform>>>().toEqualTypeOf<
+    DeepNormalize<Parameters<typeof getMaxTimeVariation>>
   >());

--- a/src/scripting/schemas/schemas.type.test.ts
+++ b/src/scripting/schemas/schemas.type.test.ts
@@ -485,9 +485,9 @@ it('buildInvalidateKeysetHashTransform output matches buildInvalidateKeysetHash 
   >().toEqualTypeOf<DeepNormalize<Parameters<typeof buildInvalidateKeysetHash>>>());
 
 it('buildSetMaxTimeVariationTransform output matches buildSetMaxTimeVariation params', () =>
-  expectTypeOf<
-    DeepNormalize<ReturnType<typeof buildSetMaxTimeVariationTransform>>
-  >().toEqualTypeOf<DeepNormalize<Parameters<typeof buildSetMaxTimeVariation>>>());
+  expectTypeOf<DeepNormalize<ReturnType<typeof buildSetMaxTimeVariationTransform>>>().toEqualTypeOf<
+    DeepNormalize<Parameters<typeof buildSetMaxTimeVariation>>
+  >());
 
 it('buildScheduleArbOSUpgradeTransform output matches buildScheduleArbOSUpgrade params', () =>
   expectTypeOf<

--- a/src/scripting/schemas/wasmModuleRoot.ts
+++ b/src/scripting/schemas/wasmModuleRoot.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { hexSchema } from './common';
+import { ConsensusVersion, WasmModuleRoot } from '../../wasmModuleRoot';
+
+export const getConsensusReleaseByVersionSchema = z.strictObject({
+  consensusVersion: z.number(),
+});
+
+export const getConsensusReleaseByVersionTransform = (
+  input: z.output<typeof getConsensusReleaseByVersionSchema>,
+): [ConsensusVersion] => [input.consensusVersion as ConsensusVersion];
+
+export const getConsensusReleaseByWasmModuleRootSchema = z.strictObject({
+  wasmModuleRoot: hexSchema,
+});
+
+export const getConsensusReleaseByWasmModuleRootTransform = (
+  input: z.output<typeof getConsensusReleaseByWasmModuleRootSchema>,
+): [WasmModuleRoot] => [input.wasmModuleRoot as WasmModuleRoot];
+
+export const isKnownWasmModuleRootSchema = z.strictObject({
+  wasmModuleRoot: hexSchema,
+});
+
+export const isKnownWasmModuleRootTransform = (
+  input: z.output<typeof isKnownWasmModuleRootSchema>,
+): Parameters<typeof import('../../wasmModuleRoot').isKnownWasmModuleRoot> => [
+  input.wasmModuleRoot,
+];


### PR DESCRIPTION
Add schemas and transforms for all 8 actions in src/actions/: write actions (buildSetIsBatchPoster, buildSetValidKeyset, buildInvalidateKeysetHash, buildSetMaxTimeVariation, buildScheduleArbOSUpgrade) and read actions (isBatchPoster, isValidKeysetHash, getMaxTimeVariation).