### PR TITLE
feat: add ArbOS 60 support

### DIFF
--- a/src/__snapshots__/prepareChainConfig.unit.test.ts.snap
+++ b/src/__snapshots__/prepareChainConfig.unit.test.ts.snap
@@ -41,7 +41,7 @@ exports[`creates chain config with defaults 1`] = `
     "DataAvailabilityCommittee": false,
     "EnableArbOS": true,
     "GenesisBlockNum": 0,
-    "InitialArbOSVersion": 51,
+    "InitialArbOSVersion": 60,
     "InitialChainOwner": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
     "MaxCodeSize": 24576,
     "MaxInitCodeSize": 49152,

--- a/src/createRollupPrepareDeploymentParamsConfig/__snapshots__/v2.1.unit.test.ts.snap
+++ b/src/createRollupPrepareDeploymentParamsConfig/__snapshots__/v2.1.unit.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`creates a config for a chain on top of a custom parent chain 1`] = `
 {
   "baseStake": 100000000000000000n,
-  "chainConfig": "{\\"chainId\\":123,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":123,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 123n,
   "confirmPeriodBlocks": 1n,
   "extraChallengeTimeBlocks": 0n,
@@ -17,14 +17,14 @@ exports[`creates a config for a chain on top of a custom parent chain 1`] = `
     "futureSeconds": 5n,
   },
   "stakeToken": "0x0000000000000000000000000000000000000000",
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;
 
 exports[`creates config for a chain on top of arbitrum one with defaults 1`] = `
 {
   "baseStake": 100000000000000000n,
-  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 69420n,
   "confirmPeriodBlocks": 50400n,
   "extraChallengeTimeBlocks": 0n,
@@ -38,7 +38,7 @@ exports[`creates config for a chain on top of arbitrum one with defaults 1`] = `
     "futureSeconds": 3600n,
   },
   "stakeToken": "0x0000000000000000000000000000000000000000",
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;
 
@@ -66,7 +66,7 @@ exports[`creates config for a chain on top of arbitrum one with overrides 1`] = 
 exports[`creates config for a chain on top of arbitrum sepolia with defaults 1`] = `
 {
   "baseStake": 100000000000000000n,
-  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 69420n,
   "confirmPeriodBlocks": 150n,
   "extraChallengeTimeBlocks": 0n,
@@ -80,7 +80,7 @@ exports[`creates config for a chain on top of arbitrum sepolia with defaults 1`]
     "futureSeconds": 3600n,
   },
   "stakeToken": "0x0000000000000000000000000000000000000000",
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;
 
@@ -108,7 +108,7 @@ exports[`creates config for a chain on top of arbitrum sepolia with overrides 1`
 exports[`creates config for a chain on top of base sepolia with defaults 1`] = `
 {
   "baseStake": 100000000000000000n,
-  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 69420n,
   "confirmPeriodBlocks": 900n,
   "extraChallengeTimeBlocks": 0n,
@@ -122,14 +122,14 @@ exports[`creates config for a chain on top of base sepolia with defaults 1`] = `
     "futureSeconds": 3600n,
   },
   "stakeToken": "0x0000000000000000000000000000000000000000",
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;
 
 exports[`creates config for a chain on top of base with defaults 1`] = `
 {
   "baseStake": 100000000000000000n,
-  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 69420n,
   "confirmPeriodBlocks": 302400n,
   "extraChallengeTimeBlocks": 0n,
@@ -143,6 +143,6 @@ exports[`creates config for a chain on top of base with defaults 1`] = `
     "futureSeconds": 3600n,
   },
   "stakeToken": "0x0000000000000000000000000000000000000000",
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;

--- a/src/createRollupPrepareDeploymentParamsConfig/__snapshots__/v3.2.unit.test.ts.snap
+++ b/src/createRollupPrepareDeploymentParamsConfig/__snapshots__/v3.2.unit.test.ts.snap
@@ -9,7 +9,7 @@ exports[`creates a config for a chain on top of a custom parent chain 1`] = `
     "replenishRateInBasis": 500n,
     "threshold": 4294967296n,
   },
-  "chainConfig": "{\\"chainId\\":123,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":123,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 123n,
   "challengeGracePeriodBlocks": 2n,
   "confirmPeriodBlocks": 1n,
@@ -49,7 +49,7 @@ exports[`creates a config for a chain on top of a custom parent chain 1`] = `
   },
   "stakeToken": "0xabaF3D9f5cbDcE54cDc43b429d8f7154A3E19Afa",
   "validatorAfkBlocks": 4n,
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;
 
@@ -62,7 +62,7 @@ exports[`creates config for a chain on top of arbitrum one with defaults 1`] = `
     "replenishRateInBasis": 500n,
     "threshold": 4294967296n,
   },
-  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 69420n,
   "challengeGracePeriodBlocks": 14400n,
   "confirmPeriodBlocks": 50400n,
@@ -102,7 +102,7 @@ exports[`creates config for a chain on top of arbitrum one with defaults 1`] = `
   },
   "stakeToken": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
   "validatorAfkBlocks": 201600n,
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;
 
@@ -168,7 +168,7 @@ exports[`creates config for a chain on top of arbitrum sepolia with defaults 1`]
     "replenishRateInBasis": 500n,
     "threshold": 4294967296n,
   },
-  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 69420n,
   "challengeGracePeriodBlocks": 14400n,
   "confirmPeriodBlocks": 150n,
@@ -208,7 +208,7 @@ exports[`creates config for a chain on top of arbitrum sepolia with defaults 1`]
   },
   "stakeToken": "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73",
   "validatorAfkBlocks": 201600n,
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;
 
@@ -274,7 +274,7 @@ exports[`creates config for a chain on top of base sepolia with defaults 1`] = `
     "replenishRateInBasis": 500n,
     "threshold": 4294967296n,
   },
-  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 69420n,
   "challengeGracePeriodBlocks": 86400n,
   "confirmPeriodBlocks": 900n,
@@ -314,7 +314,7 @@ exports[`creates config for a chain on top of base sepolia with defaults 1`] = `
   },
   "stakeToken": "0x4200000000000000000000000000000000000006",
   "validatorAfkBlocks": 1209600n,
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;
 
@@ -327,7 +327,7 @@ exports[`creates config for a chain on top of base with defaults 1`] = `
     "replenishRateInBasis": 500n,
     "threshold": 4294967296n,
   },
-  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":51,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
+  "chainConfig": "{\\"chainId\\":69420,\\"homesteadBlock\\":0,\\"daoForkBlock\\":null,\\"daoForkSupport\\":true,\\"eip150Block\\":0,\\"eip150Hash\\":\\"0x0000000000000000000000000000000000000000000000000000000000000000\\",\\"eip155Block\\":0,\\"eip158Block\\":0,\\"byzantiumBlock\\":0,\\"constantinopleBlock\\":0,\\"petersburgBlock\\":0,\\"istanbulBlock\\":0,\\"muirGlacierBlock\\":0,\\"berlinBlock\\":0,\\"londonBlock\\":0,\\"clique\\":{\\"period\\":0,\\"epoch\\":0},\\"arbitrum\\":{\\"EnableArbOS\\":true,\\"AllowDebugPrecompiles\\":false,\\"DataAvailabilityCommittee\\":false,\\"InitialArbOSVersion\\":60,\\"InitialChainOwner\\":\\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\\",\\"GenesisBlockNum\\":0,\\"MaxCodeSize\\":24576,\\"MaxInitCodeSize\\":49152}}",
   "chainId": 69420n,
   "challengeGracePeriodBlocks": 86400n,
   "confirmPeriodBlocks": 302400n,
@@ -367,6 +367,6 @@ exports[`creates config for a chain on top of base with defaults 1`] = `
   },
   "stakeToken": "0x4200000000000000000000000000000000000006",
   "validatorAfkBlocks": 1209600n,
-  "wasmModuleRoot": "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c",
+  "wasmModuleRoot": "0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57",
 }
 `;

--- a/src/createRollupPrepareDeploymentParamsConfigDefaults.ts
+++ b/src/createRollupPrepareDeploymentParamsConfigDefaults.ts
@@ -8,7 +8,7 @@ const defaultsV2Dot1 = {
   extraChallengeTimeBlocks: BigInt(0),
   stakeToken: zeroAddress,
   baseStake: parseEther(String(0.1)),
-  wasmModuleRoot: getConsensusReleaseByVersion(51.1).wasmModuleRoot,
+  wasmModuleRoot: getConsensusReleaseByVersion(60).wasmModuleRoot,
   loserStakeEscrow: zeroAddress,
   genesisBlockNum: BigInt(0),
 } as const;
@@ -38,7 +38,7 @@ const defaultsV3Dot2 = {
   layerZeroBigStepEdgeHeight: BigInt(2 ** 19),
   layerZeroSmallStepEdgeHeight: BigInt(2 ** 23),
   numBigStepLevel: 1,
-  wasmModuleRoot: getConsensusReleaseByVersion(51.1).wasmModuleRoot,
+  wasmModuleRoot: getConsensusReleaseByVersion(60).wasmModuleRoot,
 } as const;
 
 /**

--- a/src/createRollupPrepareTransactionRequest.ts
+++ b/src/createRollupPrepareTransactionRequest.ts
@@ -127,6 +127,12 @@ export async function createRollupPrepareTransactionRequest<TChain extends Chain
     );
   }
 
+  if (isDisabledWasmModuleRoot(wasmModuleRoot)) {
+    throw new Error(
+      `Wasm module root ${wasmModuleRoot} is not supported. Please update your "wasmModuleRoot" to that of a Consensus version compatible with ArbOS ${arbOSVersion}.`,
+    );
+  }
+
   if (isKnownWasmModuleRoot(wasmModuleRoot)) {
     const consensusRelease = getConsensusReleaseByWasmModuleRoot(wasmModuleRoot);
 
@@ -135,12 +141,6 @@ export async function createRollupPrepareTransactionRequest<TChain extends Chain
         `Consensus v${consensusRelease.version} does not support ArbOS ${arbOSVersion}. Please update your "wasmModuleRoot" to that of a Consensus version compatible with ArbOS ${arbOSVersion}.`,
       );
     }
-  }
-
-  if (isDisabledWasmModuleRoot(wasmModuleRoot)) {
-    throw new Error(
-      `Wasm module root ${wasmModuleRoot} is not supported. Please update your "wasmModuleRoot" to that of a Consensus version compatible with ArbOS ${arbOSVersion}.`,
-    );
   }
 
   const paramsWithDefaults = { ...defaults, ...params, maxDataSize };

--- a/src/prepareChainConfig.ts
+++ b/src/prepareChainConfig.ts
@@ -25,7 +25,7 @@ export const defaults = {
     EnableArbOS: true,
     AllowDebugPrecompiles: false,
     DataAvailabilityCommittee: false,
-    InitialArbOSVersion: 51,
+    InitialArbOSVersion: 60,
     GenesisBlockNum: 0,
     MaxCodeSize: 24_576,
     MaxInitCodeSize: 49_152,

--- a/src/wasmModuleRoot.ts
+++ b/src/wasmModuleRoot.ts
@@ -93,6 +93,12 @@ const consensusReleases = [
     wasmModuleRoot: '0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c',
     maxArbOSVersion: 51,
   },
+  {
+    // https://github.com/OffchainLabs/nitro/releases/tag/consensus-v60-rc.5
+    version: 60,
+    wasmModuleRoot: '0x7a9e6a77354888257a9989ce0b6bb39df5fedf222d453932933fdf7a489cbb57',
+    maxArbOSVersion: 60,
+  },
 ] as const satisfies readonly ConsensusRelease[];
 
 type ConsensusReleases = typeof consensusReleases;


### PR DESCRIPTION
## Summary

- Add consensus-v60-rc.5 WASM module root to `consensusReleases` table
- Update defaults to ArbOS 60: `wasmModuleRoot` (v51.1 → v60), `InitialArbOSVersion` (51 → 60)
- Fix validation order: check disabled WASM roots before version compatibility

## Context

`createRollupPrepareTransactionRequest` validates that the `wasmModuleRoot` supports the requested `InitialArbOSVersion` via `maxArbOSVersion`. Without consensus v60 in the releases table, any deployment requesting ArbOS 60 fails with:

```
Error: Consensus v51.1 does not support ArbOS 60. Please update your
"wasmModuleRoot" to that of a Consensus version compatible with ArbOS 60.
```

This blocks the [nitro-lx-operator Nitro v3.10.2 / ArbOS 60 upgrade PR](https://github.com/OffchainLabs/nitro-lx-operator/pull/356).

### Validation order fix

`createRollupPrepareTransactionRequest` checked `isKnownWasmModuleRoot` + version compatibility *before* `isDisabledWasmModuleRoot`. This meant a disabled root (e.g. the old v51.1 root `0x28b6ad83...`) paired with ArbOS 60 would produce a misleading "Consensus v51.1 does not support ArbOS 60" error instead of the correct "Wasm module root ... is not supported" error. A disabled root should be rejected unconditionally, regardless of ArbOS version.

## Changes

| File | Change |
|------|--------|
| `src/wasmModuleRoot.ts` | Add consensus v60 entry (WASM root from [consensus-v60-rc.5](https://github.com/OffchainLabs/nitro/releases/tag/consensus-v60-rc.5)) |
| `src/createRollupPrepareTransactionRequest.ts` | Move `isDisabledWasmModuleRoot` check before version compatibility check |
| `src/createRollupPrepareDeploymentParamsConfigDefaults.ts` | Default `wasmModuleRoot`: v51.1 → v60 (both v2.1 and v3.2) |
| `src/prepareChainConfig.ts` | Default `InitialArbOSVersion`: 51 → 60 |
| `src/__snapshots__/*.snap` | Updated 3 snapshot files (prepareChainConfig, v2.1, v3.2 deployment params) |

## Test plan

- [x] `vitest --config vitest.unit.config.ts --run` — 250/250 tests pass
- [x] `vitest --config vitest.type.config.ts --run` — 9/9 type tests pass