### PR TITLE
feat: add ExpressLaneAuction (Timeboost) deployment

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
 
   src:
     dependencies:
+      '@arbitrum/nitro-contracts':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@arbitrum/sdk':
         specifier: ^4.0.4
         version: 4.0.4
@@ -238,6 +241,9 @@ packages:
 
   '@arbitrum/nitro-contracts@1.1.1':
     resolution: {integrity: sha512-4Tyk3XVHz+bm8UujUC78LYSw3xAxyYvBCxfEX4z3qE4/ww7Qck/rmce5gbHMzQjArEAzAP2YSfYIFuIFuRXtfg==}
+
+  '@arbitrum/nitro-contracts@3.2.0':
+    resolution: {integrity: sha512-uiwqpgLLBpym/55YBPVItkfOnkfGRh+yWyIeTxBjSn+O0nDcEwPZhB1EQSE+eTxteD9nP7ZacAi3a9f+E/17vQ==}
 
   '@arbitrum/sdk@4.0.4':
     resolution: {integrity: sha512-GscwlkHYmPzRKs9huDHntbqx1xMRhTraTUvTC9exu+prjndKxHe9ZORuIcqmtEqwLwma/l8nqxI+k+pEEdIO6Q==}
@@ -2624,6 +2630,9 @@ packages:
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
+  solady@0.0.182:
+    resolution: {integrity: sha512-FW6xo1akJoYpkXMzu58/56FcNU3HYYNamEbnFO3iSibXk0nSHo0DV2Gu/zI3FPg3So5CCX6IYli1TT1IWATnvg==}
+
   solidity-ast@0.4.55:
     resolution: {integrity: sha512-qeEU/r/K+V5lrAw8iswf2/yfWAnSGs3WKPHI+zAFKFjX0dIBVXEU/swQ8eJQYHf6PJWUZFO2uWV4V1wEOkeQbA==}
 
@@ -2984,6 +2993,14 @@ snapshots:
       '@openzeppelin/contracts': 4.5.0
       '@openzeppelin/contracts-upgradeable': 4.5.2
       patch-package: 6.5.1
+
+  '@arbitrum/nitro-contracts@3.2.0':
+    dependencies:
+      '@offchainlabs/upgrade-executor': 1.1.0-beta.0
+      '@openzeppelin/contracts': 4.7.3
+      '@openzeppelin/contracts-upgradeable': 4.7.3
+      patch-package: 6.5.1
+      solady: 0.0.182
 
   '@arbitrum/sdk@4.0.4':
     dependencies:
@@ -5629,6 +5646,8 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.6.3
+
+  solady@0.0.182: {}
 
   solidity-ast@0.4.55:
     dependencies:

--- a/src/deployExpressLaneAuction.integration.test.ts
+++ b/src/deployExpressLaneAuction.integration.test.ts
@@ -232,33 +232,4 @@ describe('ExpressLaneAuction deployment tests', () => {
       }),
     ).rejects.toThrow(/reverted/);
   });
-
-  it('rejects before deploying when proxyAdmin has no contract code', async () => {
-    // A freshly generated EOA has no code, so the pre-flight check must reject without deploying.
-    const eoaProxyAdmin = privateKeyToAccount(generatePrivateKey()).address;
-
-    await expect(
-      deployExpressLaneAuction({
-        orbitChainWalletClient: nitroTestnodeL2WalletClient,
-        proxyAdmin: eoaProxyAdmin,
-        auctioneer,
-        biddingToken: auctioneer,
-        beneficiary,
-        roundTimingInfo: {
-          offsetTimestamp: 0n,
-          roundDurationSeconds: 60n,
-          auctionClosingSeconds: 15n,
-          reserveSubmissionSeconds: 15n,
-        },
-        minReservePrice: 1n,
-        auctioneerAdmin,
-        minReservePriceSetter,
-        reservePriceSetter,
-        reservePriceSetterAdmin,
-        beneficiarySetter,
-        roundTimingSetter,
-        masterAdmin,
-      }),
-    ).rejects.toThrow(/no contract code at proxyAdmin/);
-  });
 });

--- a/src/deployExpressLaneAuction.integration.test.ts
+++ b/src/deployExpressLaneAuction.integration.test.ts
@@ -92,10 +92,8 @@ describe('ExpressLaneAuction deployment tests', () => {
     expect(implementation).not.toEqual('0x0000000000000000000000000000000000000000');
     expect(expressLaneAuction).not.toEqual(implementation);
 
-    // The ProxyAdmin getters are the authoritative source of proxy wiring: prove the proxy's admin
-    // and implementation slots point where deployExpressLaneAuction claims, and that deployProxyAdmin
-    // made the deployer the owner (OZ Ownable sets owner = msg.sender). getProxyAdmin must be queried
-    // through the ProxyAdmin because the TransparentProxy routes admin reads away from the proxy.
+    // Query wiring through the ProxyAdmin: a TransparentProxy routes admin/implementation reads away
+    // from the proxy itself, so these getters are the authoritative source.
     const proxyAdminAbi = parseAbi([
       'function getProxyAdmin(address) view returns (address)',
       'function getProxyImplementation(address) view returns (address)',
@@ -151,9 +149,7 @@ describe('ExpressLaneAuction deployment tests', () => {
       ]),
       functionName: 'roundTimingInfo',
     });
-    // offsetTimestamp is the signed int64 field (reverts NegativeOffset() if < 0) and is stored
-    // verbatim, so it round-trips exactly to the value passed in -- assert it to catch a sign or
-    // tuple-slot encoding mistake on the riskiest field.
+    // offsetTimestamp is the signed int64 field, the riskiest to encode; assert it round-trips.
     expect(onChainRoundTimingInfo[0]).toEqual(roundTimingInfo.offsetTimestamp);
     expect(onChainRoundTimingInfo[1]).toEqual(roundTimingInfo.roundDurationSeconds);
     expect(onChainRoundTimingInfo[2]).toEqual(roundTimingInfo.auctionClosingSeconds);
@@ -166,9 +162,8 @@ describe('ExpressLaneAuction deployment tests', () => {
     });
     expect(onChainMinReservePrice).toEqual(1n);
 
-    // The 8 role addresses are passed but otherwise unobservable; reading them back through the
-    // AccessControl roles is what catches a misordered InitArgs tuple (distinct random addresses
-    // would otherwise produce wrong-but-valid values that no other assertion would notice).
+    // The role addresses are otherwise unobservable; reading them back catches a misordered
+    // InitArgs tuple that distinct-but-valid addresses would otherwise hide.
     const accessControlAbi = parseAbi([
       'function hasRole(bytes32, address) view returns (bool)',
       'function AUCTIONEER_ROLE() view returns (bytes32)',
@@ -211,9 +206,8 @@ describe('ExpressLaneAuction deployment tests', () => {
       orbitChainWalletClient: nitroTestnodeL2WalletClient,
     });
 
-    // auctionClosingSeconds + reserveSubmissionSeconds > roundDurationSeconds makes the atomic
-    // initialize revert inside the proxy constructor. The deploy must surface as an actionable
-    // error mentioning the revert, not an opaque address-parse failure on a null contractAddress.
+    // closing + reserve > duration reverts initialize inside the proxy constructor; the deploy
+    // must surface that as a revert error, not an opaque null-address parse failure.
     await expect(
       deployExpressLaneAuction({
         orbitChainWalletClient: nitroTestnodeL2WalletClient,

--- a/src/deployExpressLaneAuction.integration.test.ts
+++ b/src/deployExpressLaneAuction.integration.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Abi,
+  Address,
+  Hex,
+  createPublicClient,
+  createWalletClient,
+  getAddress,
+  http,
+  parseAbi,
+  parseEther,
+} from 'viem';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+
+import testToken from '@arbitrum/nitro-contracts/build/contracts/src/test-helpers/TestToken.sol/TestToken.json';
+
+import { nitroTestnodeL2 } from './chains';
+import { getNitroTestnodePrivateKeyAccounts } from './testHelpers';
+import { deployProxyAdmin } from './deployProxyAdmin';
+import { deployExpressLaneAuction } from './deployExpressLaneAuction';
+
+const deployer = getNitroTestnodePrivateKeyAccounts().deployer;
+
+const nitroTestnodeL2Client = createPublicClient({
+  chain: nitroTestnodeL2,
+  transport: http(nitroTestnodeL2.rpcUrls.default.http[0]),
+});
+const nitroTestnodeL2WalletClient = createWalletClient({
+  chain: nitroTestnodeL2,
+  transport: http(nitroTestnodeL2.rpcUrls.default.http[0]),
+  account: deployer,
+});
+
+// Distinct random role addresses so the assertions can't accidentally pass by
+// every field collapsing to the deployer.
+const auctioneer = privateKeyToAccount(generatePrivateKey()).address;
+const beneficiary = privateKeyToAccount(generatePrivateKey()).address;
+const auctioneerAdmin = privateKeyToAccount(generatePrivateKey()).address;
+const minReservePriceSetter = privateKeyToAccount(generatePrivateKey()).address;
+const reservePriceSetter = privateKeyToAccount(generatePrivateKey()).address;
+const reservePriceSetterAdmin = privateKeyToAccount(generatePrivateKey()).address;
+const beneficiarySetter = privateKeyToAccount(generatePrivateKey()).address;
+const roundTimingSetter = privateKeyToAccount(generatePrivateKey()).address;
+const masterAdmin = privateKeyToAccount(generatePrivateKey()).address;
+
+describe('ExpressLaneAuction deployment tests', () => {
+  it('successfully deploys a ProxyAdmin and an initialized ExpressLaneAuction', async () => {
+    const { proxyAdmin } = await deployProxyAdmin({
+      orbitChainWalletClient: nitroTestnodeL2WalletClient,
+    });
+
+    // A real ERC20 stands in as the bidding token; initialize only stores it (no
+    // method is called on it at init), but a concrete token keeps the test honest.
+    const biddingTokenTransactionHash = await nitroTestnodeL2WalletClient.deployContract({
+      abi: testToken.abi as Abi,
+      account: deployer,
+      chain: nitroTestnodeL2,
+      args: [parseEther('1000000')],
+      bytecode: testToken.bytecode as Hex,
+    });
+    const biddingTokenReceipt = await nitroTestnodeL2Client.waitForTransactionReceipt({
+      hash: biddingTokenTransactionHash,
+    });
+    const biddingToken = getAddress(biddingTokenReceipt.contractAddress as Address);
+
+    const latestBlock = await nitroTestnodeL2Client.getBlock();
+    const roundTimingInfo = {
+      offsetTimestamp: latestBlock.timestamp,
+      roundDurationSeconds: 60n,
+      auctionClosingSeconds: 15n,
+      reserveSubmissionSeconds: 15n,
+    };
+
+    const { expressLaneAuction, implementation } = await deployExpressLaneAuction({
+      orbitChainWalletClient: nitroTestnodeL2WalletClient,
+      proxyAdmin,
+      auctioneer,
+      biddingToken,
+      beneficiary,
+      roundTimingInfo,
+      minReservePrice: 1n,
+      auctioneerAdmin,
+      minReservePriceSetter,
+      reservePriceSetter,
+      reservePriceSetterAdmin,
+      beneficiarySetter,
+      roundTimingSetter,
+      masterAdmin,
+    });
+
+    expect(expressLaneAuction).not.toEqual('0x0000000000000000000000000000000000000000');
+    expect(implementation).not.toEqual('0x0000000000000000000000000000000000000000');
+    expect(expressLaneAuction).not.toEqual(implementation);
+
+    // The ProxyAdmin getters are the authoritative source of proxy wiring: prove the proxy's admin
+    // and implementation slots point where deployExpressLaneAuction claims, and that deployProxyAdmin
+    // made the deployer the owner (OZ Ownable sets owner = msg.sender). getProxyAdmin must be queried
+    // through the ProxyAdmin because the TransparentProxy routes admin reads away from the proxy.
+    const proxyAdminAbi = parseAbi([
+      'function getProxyAdmin(address) view returns (address)',
+      'function getProxyImplementation(address) view returns (address)',
+      'function owner() view returns (address)',
+    ]);
+    const onChainProxyAdmin = await nitroTestnodeL2Client.readContract({
+      address: proxyAdmin,
+      abi: proxyAdminAbi,
+      functionName: 'getProxyAdmin',
+      args: [expressLaneAuction],
+    });
+    expect(onChainProxyAdmin).toEqual(proxyAdmin);
+    const onChainImplementation = await nitroTestnodeL2Client.readContract({
+      address: proxyAdmin,
+      abi: proxyAdminAbi,
+      functionName: 'getProxyImplementation',
+      args: [expressLaneAuction],
+    });
+    expect(onChainImplementation).toEqual(implementation);
+    const proxyAdminOwner = await nitroTestnodeL2Client.readContract({
+      address: proxyAdmin,
+      abi: proxyAdminAbi,
+      functionName: 'owner',
+    });
+    expect(proxyAdminOwner).toEqual(getAddress(deployer.address));
+
+    // Reads go through the proxy, proving initialize ran via delegatecall.
+    const onChainBiddingToken = await nitroTestnodeL2Client.readContract({
+      address: expressLaneAuction,
+      abi: parseAbi(['function biddingToken() view returns (address)']),
+      functionName: 'biddingToken',
+    });
+    expect(onChainBiddingToken).toEqual(biddingToken);
+
+    const reservePrice = await nitroTestnodeL2Client.readContract({
+      address: expressLaneAuction,
+      abi: parseAbi(['function reservePrice() view returns (uint256)']),
+      functionName: 'reservePrice',
+    });
+    expect(reservePrice).toEqual(1n);
+
+    const onChainBeneficiary = await nitroTestnodeL2Client.readContract({
+      address: expressLaneAuction,
+      abi: parseAbi(['function beneficiary() view returns (address)']),
+      functionName: 'beneficiary',
+    });
+    expect(onChainBeneficiary).toEqual(beneficiary);
+
+    const onChainRoundTimingInfo = await nitroTestnodeL2Client.readContract({
+      address: expressLaneAuction,
+      abi: parseAbi([
+        'function roundTimingInfo() view returns (int64 offsetTimestamp, uint64 roundDurationSeconds, uint64 auctionClosingSeconds, uint64 reserveSubmissionSeconds)',
+      ]),
+      functionName: 'roundTimingInfo',
+    });
+    // offsetTimestamp is the signed int64 field (reverts NegativeOffset() if < 0) and is stored
+    // verbatim, so it round-trips exactly to the value passed in -- assert it to catch a sign or
+    // tuple-slot encoding mistake on the riskiest field.
+    expect(onChainRoundTimingInfo[0]).toEqual(roundTimingInfo.offsetTimestamp);
+    expect(onChainRoundTimingInfo[1]).toEqual(roundTimingInfo.roundDurationSeconds);
+    expect(onChainRoundTimingInfo[2]).toEqual(roundTimingInfo.auctionClosingSeconds);
+    expect(onChainRoundTimingInfo[3]).toEqual(roundTimingInfo.reserveSubmissionSeconds);
+
+    const onChainMinReservePrice = await nitroTestnodeL2Client.readContract({
+      address: expressLaneAuction,
+      abi: parseAbi(['function minReservePrice() view returns (uint256)']),
+      functionName: 'minReservePrice',
+    });
+    expect(onChainMinReservePrice).toEqual(1n);
+
+    // The 8 role addresses are passed but otherwise unobservable; reading them back through the
+    // AccessControl roles is what catches a misordered InitArgs tuple (distinct random addresses
+    // would otherwise produce wrong-but-valid values that no other assertion would notice).
+    const accessControlAbi = parseAbi([
+      'function hasRole(bytes32, address) view returns (bool)',
+      'function AUCTIONEER_ROLE() view returns (bytes32)',
+      'function AUCTIONEER_ADMIN_ROLE() view returns (bytes32)',
+      'function MIN_RESERVE_SETTER_ROLE() view returns (bytes32)',
+      'function RESERVE_SETTER_ROLE() view returns (bytes32)',
+      'function RESERVE_SETTER_ADMIN_ROLE() view returns (bytes32)',
+      'function BENEFICIARY_SETTER_ROLE() view returns (bytes32)',
+      'function ROUND_TIMING_SETTER_ROLE() view returns (bytes32)',
+      'function DEFAULT_ADMIN_ROLE() view returns (bytes32)',
+    ]);
+    const roleHolders: [string, Address][] = [
+      ['AUCTIONEER_ROLE', auctioneer],
+      ['AUCTIONEER_ADMIN_ROLE', auctioneerAdmin],
+      ['MIN_RESERVE_SETTER_ROLE', minReservePriceSetter],
+      ['RESERVE_SETTER_ROLE', reservePriceSetter],
+      ['RESERVE_SETTER_ADMIN_ROLE', reservePriceSetterAdmin],
+      ['BENEFICIARY_SETTER_ROLE', beneficiarySetter],
+      ['ROUND_TIMING_SETTER_ROLE', roundTimingSetter],
+      ['DEFAULT_ADMIN_ROLE', masterAdmin],
+    ];
+    for (const [roleName, holder] of roleHolders) {
+      const roleId = await nitroTestnodeL2Client.readContract({
+        address: expressLaneAuction,
+        abi: accessControlAbi,
+        functionName: roleName as 'AUCTIONEER_ROLE',
+      });
+      const holdsRole = await nitroTestnodeL2Client.readContract({
+        address: expressLaneAuction,
+        abi: accessControlAbi,
+        functionName: 'hasRole',
+        args: [roleId, holder],
+      });
+      expect(holdsRole, `expected ${holder} to hold ${roleName}`).toEqual(true);
+    }
+  });
+
+  it('rejects with a revert error when roundTimingInfo is invalid', async () => {
+    const { proxyAdmin } = await deployProxyAdmin({
+      orbitChainWalletClient: nitroTestnodeL2WalletClient,
+    });
+
+    // auctionClosingSeconds + reserveSubmissionSeconds > roundDurationSeconds makes the atomic
+    // initialize revert inside the proxy constructor. The deploy must surface as an actionable
+    // error mentioning the revert, not an opaque address-parse failure on a null contractAddress.
+    await expect(
+      deployExpressLaneAuction({
+        orbitChainWalletClient: nitroTestnodeL2WalletClient,
+        proxyAdmin,
+        auctioneer,
+        biddingToken: auctioneer,
+        beneficiary,
+        roundTimingInfo: {
+          offsetTimestamp: 0n,
+          roundDurationSeconds: 60n,
+          auctionClosingSeconds: 50n,
+          reserveSubmissionSeconds: 50n,
+        },
+        minReservePrice: 1n,
+        auctioneerAdmin,
+        minReservePriceSetter,
+        reservePriceSetter,
+        reservePriceSetterAdmin,
+        beneficiarySetter,
+        roundTimingSetter,
+        masterAdmin,
+      }),
+    ).rejects.toThrow(/reverted/);
+  });
+
+  it('rejects before deploying when proxyAdmin has no contract code', async () => {
+    // A freshly generated EOA has no code, so the pre-flight check must reject without deploying.
+    const eoaProxyAdmin = privateKeyToAccount(generatePrivateKey()).address;
+
+    await expect(
+      deployExpressLaneAuction({
+        orbitChainWalletClient: nitroTestnodeL2WalletClient,
+        proxyAdmin: eoaProxyAdmin,
+        auctioneer,
+        biddingToken: auctioneer,
+        beneficiary,
+        roundTimingInfo: {
+          offsetTimestamp: 0n,
+          roundDurationSeconds: 60n,
+          auctionClosingSeconds: 15n,
+          reserveSubmissionSeconds: 15n,
+        },
+        minReservePrice: 1n,
+        auctioneerAdmin,
+        minReservePriceSetter,
+        reservePriceSetter,
+        reservePriceSetterAdmin,
+        beneficiarySetter,
+        roundTimingSetter,
+        masterAdmin,
+      }),
+    ).rejects.toThrow(/no contract code at proxyAdmin/);
+  });
+});

--- a/src/deployExpressLaneAuction.ts
+++ b/src/deployExpressLaneAuction.ts
@@ -1,0 +1,243 @@
+import {
+  Abi,
+  Address,
+  Hex,
+  WalletClient,
+  encodeFunctionData,
+  getAddress,
+  publicActions,
+} from 'viem';
+
+import expressLaneAuction from '@arbitrum/nitro-contracts/build/contracts/src/express-lane-auction/ExpressLaneAuction.sol/ExpressLaneAuction.json';
+import transparentUpgradeableProxy from '@arbitrum/nitro-contracts/build/contracts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json';
+
+/**
+ * This type describes the round timing of the ExpressLaneAuction. Durations are in seconds.
+ */
+export type ExpressLaneAuctionRoundTimingInfo = {
+  offsetTimestamp: bigint;
+  roundDurationSeconds: bigint;
+  auctionClosingSeconds: bigint;
+  reserveSubmissionSeconds: bigint;
+};
+
+/**
+ * This type is for the params of the deployExpressLaneAuction function
+ */
+export type DeployExpressLaneAuctionParams = {
+  orbitChainWalletClient: WalletClient;
+  proxyAdmin: Address;
+  auctioneer: Address;
+  biddingToken: Address;
+  beneficiary: Address;
+  roundTimingInfo: ExpressLaneAuctionRoundTimingInfo;
+  minReservePrice: bigint;
+  auctioneerAdmin: Address;
+  minReservePriceSetter: Address;
+  reservePriceSetter: Address;
+  reservePriceSetterAdmin: Address;
+  beneficiarySetter: Address;
+  roundTimingSetter: Address;
+  masterAdmin: Address;
+};
+
+/**
+ * This type is for the result of the deployExpressLaneAuction function
+ */
+export type DeployExpressLaneAuctionResult = {
+  expressLaneAuction: Address;
+  implementation: Address;
+  transactionHash: Hex;
+};
+
+/**
+ * The ExpressLaneAuction initialize arguments: everything in DeployExpressLaneAuctionParams
+ * except the deploy machinery (the wallet client and the proxy admin).
+ */
+export type ExpressLaneAuctionInitArgs = Omit<
+  DeployExpressLaneAuctionParams,
+  'orbitChainWalletClient' | 'proxyAdmin'
+>;
+
+/**
+ * Encodes the ExpressLaneAuction `initialize(InitArgs)` calldata. This is the single source of truth
+ * for the InitArgs tuple component names: deployExpressLaneAuction encodes it into the proxy
+ * constructor's data argument, and the unit test round-trips it so a renamed or dropped key fails in
+ * CI here rather than at deploy time. The JSON-imported ABI is cast to Abi, which erases compile-time
+ * checking of the 12 near-identical keys, so the round-trip is the only guard against a typo.
+ */
+export function encodeExpressLaneAuctionInitData(initArgs: ExpressLaneAuctionInitArgs): Hex {
+  return encodeFunctionData({
+    abi: expressLaneAuction.abi as Abi,
+    functionName: 'initialize',
+    args: [
+      {
+        _auctioneer: initArgs.auctioneer,
+        _biddingToken: initArgs.biddingToken,
+        _beneficiary: initArgs.beneficiary,
+        _roundTimingInfo: initArgs.roundTimingInfo,
+        _minReservePrice: initArgs.minReservePrice,
+        _auctioneerAdmin: initArgs.auctioneerAdmin,
+        _minReservePriceSetter: initArgs.minReservePriceSetter,
+        _reservePriceSetter: initArgs.reservePriceSetter,
+        _reservePriceSetterAdmin: initArgs.reservePriceSetterAdmin,
+        _beneficiarySetter: initArgs.beneficiarySetter,
+        _roundTimingSetter: initArgs.roundTimingSetter,
+        _masterAdmin: initArgs.masterAdmin,
+      },
+    ],
+  });
+}
+
+/**
+ * Deploys the Timeboost ExpressLaneAuction logic contract and an initialized
+ * TransparentUpgradeableProxy in front of it on the orbit (child) chain.
+ *
+ * The proxy is what callers interact with; the logic contract holds no state. ExpressLaneAuction's
+ * initialize is guarded by onlyDelegated, so it reverts if called on the implementation directly.
+ * We therefore encode initialize into the proxy constructor's data argument: it runs via delegatecall
+ * atomically with deployment, exactly like the orbit-actions Foundry deployment script.
+ *
+ * The proxy admin must already exist (deploy it first with deployProxyAdmin); it is the contract that
+ * can later upgrade this proxy.
+ *
+ * References:
+ * - ExpressLaneAuction contract: https://github.com/OffchainLabs/nitro-contracts/blob/v3.2.0/src/express-lane-auction/ExpressLaneAuction.sol
+ * - TransparentUpgradeableProxy contract: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v4.7/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+ *
+ * @param {DeployExpressLaneAuctionParams} deployExpressLaneAuctionParams {@link DeployExpressLaneAuctionParams}
+ * @param {WalletClient} deployExpressLaneAuctionParams.orbitChainWalletClient - The orbit chain Viem wallet client (this account deploys both contracts)
+ * @param {Address} deployExpressLaneAuctionParams.proxyAdmin - The already-deployed ProxyAdmin that will own/upgrade the proxy
+ * @param {Address} deployExpressLaneAuctionParams.auctioneer - The account that resolves auctions
+ * @param {Address} deployExpressLaneAuctionParams.biddingToken - The ERC20 token used to place bids
+ * @param {Address} deployExpressLaneAuctionParams.beneficiary - The account that receives auction proceeds
+ * @param {ExpressLaneAuctionRoundTimingInfo} deployExpressLaneAuctionParams.roundTimingInfo - The auction round timing {@link ExpressLaneAuctionRoundTimingInfo}
+ * @param {bigint} deployExpressLaneAuctionParams.roundTimingInfo.offsetTimestamp - The unix timestamp (seconds, signed int64) the first round is offset from; must be >= 0
+ * @param {bigint} deployExpressLaneAuctionParams.roundTimingInfo.roundDurationSeconds - The duration of each round in seconds; must be in (0, 86400]
+ * @param {bigint} deployExpressLaneAuctionParams.roundTimingInfo.auctionClosingSeconds - Seconds before a round during which bidding is closed; must be > 0
+ * @param {bigint} deployExpressLaneAuctionParams.roundTimingInfo.reserveSubmissionSeconds - Seconds reserved for reserve-price submission; auctionClosingSeconds + reserveSubmissionSeconds must be <= roundDurationSeconds
+ * @param {bigint} deployExpressLaneAuctionParams.minReservePrice - The minimum reserve price; reservePrice is initialized to this value
+ * @param {Address} deployExpressLaneAuctionParams.auctioneerAdmin - Admin role for the auctioneer
+ * @param {Address} deployExpressLaneAuctionParams.minReservePriceSetter - The account that can set the minimum reserve price
+ * @param {Address} deployExpressLaneAuctionParams.reservePriceSetter - The account that can set the reserve price
+ * @param {Address} deployExpressLaneAuctionParams.reservePriceSetterAdmin - Admin role for the reserve-price setter
+ * @param {Address} deployExpressLaneAuctionParams.beneficiarySetter - The account that can change the beneficiary
+ * @param {Address} deployExpressLaneAuctionParams.roundTimingSetter - The account that can change the round timing
+ * @param {Address} deployExpressLaneAuctionParams.masterAdmin - Holds DEFAULT_ADMIN_ROLE; the admin for any role without a dedicated admin
+ *
+ * @returns Promise<DeployExpressLaneAuctionResult> {@link DeployExpressLaneAuctionResult} - The proxy address (expressLaneAuction), the implementation address, and the proxy deployment transaction hash
+ *
+ * @example
+ * const { proxyAdmin } = await deployProxyAdmin({ orbitChainWalletClient });
+ * const { expressLaneAuction } = await deployExpressLaneAuction({
+ *   orbitChainWalletClient,
+ *   proxyAdmin,
+ *   auctioneer,
+ *   biddingToken,
+ *   beneficiary,
+ *   roundTimingInfo: {
+ *     offsetTimestamp: 0n,
+ *     roundDurationSeconds: 60n,
+ *     auctionClosingSeconds: 15n,
+ *     reserveSubmissionSeconds: 15n,
+ *   },
+ *   minReservePrice: 1n,
+ *   auctioneerAdmin,
+ *   minReservePriceSetter,
+ *   reservePriceSetter,
+ *   reservePriceSetterAdmin,
+ *   beneficiarySetter,
+ *   roundTimingSetter,
+ *   masterAdmin,
+ * });
+ */
+export async function deployExpressLaneAuction({
+  orbitChainWalletClient,
+  proxyAdmin,
+  auctioneer,
+  biddingToken,
+  beneficiary,
+  roundTimingInfo,
+  minReservePrice,
+  auctioneerAdmin,
+  minReservePriceSetter,
+  reservePriceSetter,
+  reservePriceSetterAdmin,
+  beneficiarySetter,
+  roundTimingSetter,
+  masterAdmin,
+}: DeployExpressLaneAuctionParams): Promise<DeployExpressLaneAuctionResult> {
+  const client = orbitChainWalletClient.extend(publicActions);
+
+  // A TransparentUpgradeableProxy stores its admin without ever calling it, so a non-contract
+  // proxyAdmin (an EOA, or the caller's own address) yields a permanently unadministrable proxy --
+  // and if it is the caller's address, admin routing also hides the auction's own methods. Fail fast
+  // before spending gas on the implementation deploy if there is no code at proxyAdmin.
+  const proxyAdminCode = await client.getBytecode({ address: proxyAdmin });
+  if (!proxyAdminCode || proxyAdminCode === '0x') {
+    throw new Error(
+      `deployExpressLaneAuction: no contract code at proxyAdmin ${proxyAdmin}; deploy one with deployProxyAdmin first`,
+    );
+  }
+
+  // The proxy constructor needs the implementation address, so deploy the logic contract first.
+  const implementationTransactionHash = await client.deployContract({
+    abi: expressLaneAuction.abi,
+    account: orbitChainWalletClient.account!,
+    chain: orbitChainWalletClient.chain,
+    bytecode: expressLaneAuction.bytecode as Hex,
+  });
+  const implementationReceipt = await client.waitForTransactionReceipt({
+    hash: implementationTransactionHash,
+  });
+  // waitForTransactionReceipt does not reject on revert in this viem version, so a reverted
+  // deploy yields contractAddress: null; surface it with the tx hash instead of letting
+  // getAddress(null) throw an opaque InvalidAddressError.
+  if (implementationReceipt.status === 'reverted' || !implementationReceipt.contractAddress) {
+    throw new Error(
+      `deployExpressLaneAuction: implementation deployment ${implementationTransactionHash} reverted (status=${implementationReceipt.status})`,
+    );
+  }
+  const implementation = getAddress(implementationReceipt.contractAddress);
+
+  // initialize is onlyDelegated, so encode it into the proxy constructor's _data argument: it runs
+  // through the proxy via delegatecall, never against the implementation directly.
+  const initData = encodeExpressLaneAuctionInitData({
+    auctioneer,
+    biddingToken,
+    beneficiary,
+    roundTimingInfo,
+    minReservePrice,
+    auctioneerAdmin,
+    minReservePriceSetter,
+    reservePriceSetter,
+    reservePriceSetterAdmin,
+    beneficiarySetter,
+    roundTimingSetter,
+    masterAdmin,
+  });
+
+  const transactionHash = await client.deployContract({
+    abi: transparentUpgradeableProxy.abi,
+    account: orbitChainWalletClient.account!,
+    chain: orbitChainWalletClient.chain,
+    args: [implementation, proxyAdmin, initData],
+    bytecode: transparentUpgradeableProxy.bytecode as Hex,
+  });
+  const receipt = await client.waitForTransactionReceipt({ hash: transactionHash });
+
+  // The proxy constructor runs initialize via delegatecall, so any initialize revert path
+  // (NegativeOffset, invalid roundTimingInfo, onlyDelegated) reverts the proxy deploy and yields
+  // contractAddress: null. Surface it with the tx hash so the failing validation is identifiable.
+  if (receipt.status === 'reverted' || !receipt.contractAddress) {
+    throw new Error(
+      `deployExpressLaneAuction: proxy deployment ${transactionHash} reverted (status=${receipt.status})`,
+    );
+  }
+
+  return {
+    expressLaneAuction: getAddress(receipt.contractAddress),
+    implementation,
+    transactionHash,
+  };
+}

--- a/src/deployExpressLaneAuction.ts
+++ b/src/deployExpressLaneAuction.ts
@@ -169,10 +169,7 @@ export async function deployExpressLaneAuction({
 }: DeployExpressLaneAuctionParams): Promise<DeployExpressLaneAuctionResult> {
   const client = orbitChainWalletClient.extend(publicActions);
 
-  // A TransparentUpgradeableProxy stores its admin without ever calling it, so a non-contract
-  // proxyAdmin (an EOA, or the caller's own address) yields a permanently unadministrable proxy --
-  // and if it is the caller's address, admin routing also hides the auction's own methods. Fail fast
-  // before spending gas on the implementation deploy if there is no code at proxyAdmin.
+  // Sanity check the proxy admin isn't an EOA.
   const proxyAdminCode = await client.getBytecode({ address: proxyAdmin });
   if (!proxyAdminCode || proxyAdminCode === '0x') {
     throw new Error(

--- a/src/deployExpressLaneAuction.ts
+++ b/src/deployExpressLaneAuction.ts
@@ -140,31 +140,11 @@ export function encodeExpressLaneAuctionInitData(initArgs: ExpressLaneAuctionIni
  *   masterAdmin,
  * });
  */
-export async function deployExpressLaneAuction({
-  orbitChainWalletClient,
-  proxyAdmin,
-  auctioneer,
-  biddingToken,
-  beneficiary,
-  roundTimingInfo,
-  minReservePrice,
-  auctioneerAdmin,
-  minReservePriceSetter,
-  reservePriceSetter,
-  reservePriceSetterAdmin,
-  beneficiarySetter,
-  roundTimingSetter,
-  masterAdmin,
-}: DeployExpressLaneAuctionParams): Promise<DeployExpressLaneAuctionResult> {
+export async function deployExpressLaneAuction(
+  deployExpressLaneAuctionParams: DeployExpressLaneAuctionParams,
+): Promise<DeployExpressLaneAuctionResult> {
+  const { orbitChainWalletClient, proxyAdmin, ...initArgs } = deployExpressLaneAuctionParams;
   const client = orbitChainWalletClient.extend(publicActions);
-
-  // Sanity check the proxy admin isn't an EOA.
-  const proxyAdminCode = await client.getBytecode({ address: proxyAdmin });
-  if (!proxyAdminCode || proxyAdminCode === '0x') {
-    throw new Error(
-      `deployExpressLaneAuction: no contract code at proxyAdmin ${proxyAdmin}; deploy one with deployProxyAdmin first`,
-    );
-  }
 
   const implementationTransactionHash = await client.deployContract({
     abi: expressLaneAuction.abi,
@@ -182,20 +162,7 @@ export async function deployExpressLaneAuction({
   }
   const implementation = getAddress(implementationReceipt.contractAddress);
 
-  const initData = encodeExpressLaneAuctionInitData({
-    auctioneer,
-    biddingToken,
-    beneficiary,
-    roundTimingInfo,
-    minReservePrice,
-    auctioneerAdmin,
-    minReservePriceSetter,
-    reservePriceSetter,
-    reservePriceSetterAdmin,
-    beneficiarySetter,
-    roundTimingSetter,
-    masterAdmin,
-  });
+  const initData = encodeExpressLaneAuctionInitData(initArgs);
 
   const transactionHash = await client.deployContract({
     abi: transparentUpgradeableProxy.abi,

--- a/src/deployExpressLaneAuction.ts
+++ b/src/deployExpressLaneAuction.ts
@@ -51,9 +51,7 @@ export type ExpressLaneAuctionInitArgs = Omit<
 >;
 
 /**
- * Encodes the ExpressLaneAuction `initialize(InitArgs)` calldata. The JSON ABI is cast to `Abi`, so a
- * renamed or dropped InitArgs key escapes the compiler; the unit test round-trips this encoder so such
- * a typo fails in CI rather than at deploy time.
+ * Encodes the ExpressLaneAuction `initialize(InitArgs)` calldata.
  */
 export function encodeExpressLaneAuctionInitData(initArgs: ExpressLaneAuctionInitArgs): Hex {
   return encodeFunctionData({
@@ -82,11 +80,6 @@ export function encodeExpressLaneAuctionInitData(initArgs: ExpressLaneAuctionIni
  * Deploys the Timeboost ExpressLaneAuction logic contract and an initialized
  * TransparentUpgradeableProxy in front of it on the orbit (child) chain.
  *
- * The proxy is what callers interact with; the logic contract holds no state. ExpressLaneAuction's
- * initialize is guarded by onlyDelegated, so it reverts if called on the implementation directly.
- * We therefore encode initialize into the proxy constructor's data argument: it runs via delegatecall
- * atomically with deployment, exactly like the orbit-actions Foundry deployment script.
- *
  * The proxy admin must already exist (deploy it first with deployProxyAdmin); it is the contract that
  * can later upgrade this proxy.
  *
@@ -113,32 +106,6 @@ export function encodeExpressLaneAuctionInitData(initArgs: ExpressLaneAuctionIni
  * @param {Address} deployExpressLaneAuctionParams.beneficiarySetter - The account that can change the beneficiary
  * @param {Address} deployExpressLaneAuctionParams.roundTimingSetter - The account that can change the round timing
  * @param {Address} deployExpressLaneAuctionParams.masterAdmin - Holds DEFAULT_ADMIN_ROLE; the admin for any role without a dedicated admin
- *
- * @returns Promise<DeployExpressLaneAuctionResult> {@link DeployExpressLaneAuctionResult} - The proxy address (expressLaneAuction), the implementation address, and the proxy deployment transaction hash
- *
- * @example
- * const { proxyAdmin } = await deployProxyAdmin({ orbitChainWalletClient });
- * const { expressLaneAuction } = await deployExpressLaneAuction({
- *   orbitChainWalletClient,
- *   proxyAdmin,
- *   auctioneer,
- *   biddingToken,
- *   beneficiary,
- *   roundTimingInfo: {
- *     offsetTimestamp: 0n,
- *     roundDurationSeconds: 60n,
- *     auctionClosingSeconds: 15n,
- *     reserveSubmissionSeconds: 15n,
- *   },
- *   minReservePrice: 1n,
- *   auctioneerAdmin,
- *   minReservePriceSetter,
- *   reservePriceSetter,
- *   reservePriceSetterAdmin,
- *   beneficiarySetter,
- *   roundTimingSetter,
- *   masterAdmin,
- * });
  */
 export async function deployExpressLaneAuction(
   deployExpressLaneAuctionParams: DeployExpressLaneAuctionParams,

--- a/src/deployExpressLaneAuction.ts
+++ b/src/deployExpressLaneAuction.ts
@@ -11,9 +11,6 @@ import {
 import expressLaneAuction from '@arbitrum/nitro-contracts/build/contracts/src/express-lane-auction/ExpressLaneAuction.sol/ExpressLaneAuction.json';
 import transparentUpgradeableProxy from '@arbitrum/nitro-contracts/build/contracts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json';
 
-/**
- * This type describes the round timing of the ExpressLaneAuction. Durations are in seconds.
- */
 export type ExpressLaneAuctionRoundTimingInfo = {
   offsetTimestamp: bigint;
   roundDurationSeconds: bigint;
@@ -21,9 +18,6 @@ export type ExpressLaneAuctionRoundTimingInfo = {
   reserveSubmissionSeconds: bigint;
 };
 
-/**
- * This type is for the params of the deployExpressLaneAuction function
- */
 export type DeployExpressLaneAuctionParams = {
   orbitChainWalletClient: WalletClient;
   proxyAdmin: Address;
@@ -41,9 +35,6 @@ export type DeployExpressLaneAuctionParams = {
   masterAdmin: Address;
 };
 
-/**
- * This type is for the result of the deployExpressLaneAuction function
- */
 export type DeployExpressLaneAuctionResult = {
   expressLaneAuction: Address;
   implementation: Address;
@@ -60,11 +51,9 @@ export type ExpressLaneAuctionInitArgs = Omit<
 >;
 
 /**
- * Encodes the ExpressLaneAuction `initialize(InitArgs)` calldata. This is the single source of truth
- * for the InitArgs tuple component names: deployExpressLaneAuction encodes it into the proxy
- * constructor's data argument, and the unit test round-trips it so a renamed or dropped key fails in
- * CI here rather than at deploy time. The JSON-imported ABI is cast to Abi, which erases compile-time
- * checking of the 12 near-identical keys, so the round-trip is the only guard against a typo.
+ * Encodes the ExpressLaneAuction `initialize(InitArgs)` calldata. The JSON ABI is cast to `Abi`, so a
+ * renamed or dropped InitArgs key escapes the compiler; the unit test round-trips this encoder so such
+ * a typo fails in CI rather than at deploy time.
  */
 export function encodeExpressLaneAuctionInitData(initArgs: ExpressLaneAuctionInitArgs): Hex {
   return encodeFunctionData({
@@ -177,7 +166,6 @@ export async function deployExpressLaneAuction({
     );
   }
 
-  // The proxy constructor needs the implementation address, so deploy the logic contract first.
   const implementationTransactionHash = await client.deployContract({
     abi: expressLaneAuction.abi,
     account: orbitChainWalletClient.account!,
@@ -187,9 +175,6 @@ export async function deployExpressLaneAuction({
   const implementationReceipt = await client.waitForTransactionReceipt({
     hash: implementationTransactionHash,
   });
-  // waitForTransactionReceipt does not reject on revert in this viem version, so a reverted
-  // deploy yields contractAddress: null; surface it with the tx hash instead of letting
-  // getAddress(null) throw an opaque InvalidAddressError.
   if (implementationReceipt.status === 'reverted' || !implementationReceipt.contractAddress) {
     throw new Error(
       `deployExpressLaneAuction: implementation deployment ${implementationTransactionHash} reverted (status=${implementationReceipt.status})`,
@@ -197,8 +182,6 @@ export async function deployExpressLaneAuction({
   }
   const implementation = getAddress(implementationReceipt.contractAddress);
 
-  // initialize is onlyDelegated, so encode it into the proxy constructor's _data argument: it runs
-  // through the proxy via delegatecall, never against the implementation directly.
   const initData = encodeExpressLaneAuctionInitData({
     auctioneer,
     biddingToken,
@@ -223,9 +206,6 @@ export async function deployExpressLaneAuction({
   });
   const receipt = await client.waitForTransactionReceipt({ hash: transactionHash });
 
-  // The proxy constructor runs initialize via delegatecall, so any initialize revert path
-  // (NegativeOffset, invalid roundTimingInfo, onlyDelegated) reverts the proxy deploy and yields
-  // contractAddress: null. Surface it with the tx hash so the failing validation is identifiable.
   if (receipt.status === 'reverted' || !receipt.contractAddress) {
     throw new Error(
       `deployExpressLaneAuction: proxy deployment ${transactionHash} reverted (status=${receipt.status})`,

--- a/src/deployExpressLaneAuction.unit.test.ts
+++ b/src/deployExpressLaneAuction.unit.test.ts
@@ -5,11 +5,8 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import expressLaneAuction from '@arbitrum/nitro-contracts/build/contracts/src/express-lane-auction/ExpressLaneAuction.sol/ExpressLaneAuction.json';
 import { encodeExpressLaneAuctionInitData } from './deployExpressLaneAuction';
 
-// encodeExpressLaneAuctionInitData is the single source of truth for the InitArgs tuple keys that
-// deployExpressLaneAuction sends on-chain. Because the JSON-imported ABI is cast to Abi, a renamed or
-// dropped key in that encoder is invisible to the compiler; round-tripping the *production* encoder
-// through the real ABI makes such a typo fail here in CI rather than at live deploy time with viem's
-// opaque "Address undefined is invalid" error.
+// The JSON ABI is cast to Abi, so a renamed or dropped InitArgs key is invisible to the compiler.
+// Round-tripping the production encoder through the real ABI makes such a typo fail here, not at deploy.
 describe('deployExpressLaneAuction initialize encoding', () => {
   it('encodes the production InitArgs and decodes back to the same values', () => {
     const randomAddress = () => privateKeyToAccount(generatePrivateKey()).address;

--- a/src/deployExpressLaneAuction.unit.test.ts
+++ b/src/deployExpressLaneAuction.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { Abi, decodeFunctionData } from 'viem';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+
+import expressLaneAuction from '@arbitrum/nitro-contracts/build/contracts/src/express-lane-auction/ExpressLaneAuction.sol/ExpressLaneAuction.json';
+import { encodeExpressLaneAuctionInitData } from './deployExpressLaneAuction';
+
+// encodeExpressLaneAuctionInitData is the single source of truth for the InitArgs tuple keys that
+// deployExpressLaneAuction sends on-chain. Because the JSON-imported ABI is cast to Abi, a renamed or
+// dropped key in that encoder is invisible to the compiler; round-tripping the *production* encoder
+// through the real ABI makes such a typo fail here in CI rather than at live deploy time with viem's
+// opaque "Address undefined is invalid" error.
+describe('deployExpressLaneAuction initialize encoding', () => {
+  it('encodes the production InitArgs and decodes back to the same values', () => {
+    const randomAddress = () => privateKeyToAccount(generatePrivateKey()).address;
+    const initArgs = {
+      auctioneer: randomAddress(),
+      biddingToken: randomAddress(),
+      beneficiary: randomAddress(),
+      roundTimingInfo: {
+        offsetTimestamp: 123n,
+        roundDurationSeconds: 60n,
+        auctionClosingSeconds: 15n,
+        reserveSubmissionSeconds: 15n,
+      },
+      minReservePrice: 1n,
+      auctioneerAdmin: randomAddress(),
+      minReservePriceSetter: randomAddress(),
+      reservePriceSetter: randomAddress(),
+      reservePriceSetterAdmin: randomAddress(),
+      beneficiarySetter: randomAddress(),
+      roundTimingSetter: randomAddress(),
+      masterAdmin: randomAddress(),
+    };
+
+    const data = encodeExpressLaneAuctionInitData(initArgs);
+    const decoded = decodeFunctionData({ abi: expressLaneAuction.abi as Abi, data });
+
+    expect(decoded.functionName).toEqual('initialize');
+    expect(decoded.args).toEqual([
+      {
+        _auctioneer: initArgs.auctioneer,
+        _biddingToken: initArgs.biddingToken,
+        _beneficiary: initArgs.beneficiary,
+        _roundTimingInfo: initArgs.roundTimingInfo,
+        _minReservePrice: initArgs.minReservePrice,
+        _auctioneerAdmin: initArgs.auctioneerAdmin,
+        _minReservePriceSetter: initArgs.minReservePriceSetter,
+        _reservePriceSetter: initArgs.reservePriceSetter,
+        _reservePriceSetterAdmin: initArgs.reservePriceSetterAdmin,
+        _beneficiarySetter: initArgs.beneficiarySetter,
+        _roundTimingSetter: initArgs.roundTimingSetter,
+        _masterAdmin: initArgs.masterAdmin,
+      },
+    ]);
+  });
+});

--- a/src/deployProxyAdmin.ts
+++ b/src/deployProxyAdmin.ts
@@ -2,16 +2,10 @@ import { Address, Hex, WalletClient, getAddress, publicActions } from 'viem';
 
 import proxyAdmin from '@arbitrum/nitro-contracts/build/contracts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json';
 
-/**
- * This type is for the params of the deployProxyAdmin function
- */
 export type DeployProxyAdminParams = {
   orbitChainWalletClient: WalletClient;
 };
 
-/**
- * This type is for the result of the deployProxyAdmin function
- */
 export type DeployProxyAdminResult = {
   proxyAdmin: Address;
   transactionHash: Hex;
@@ -36,7 +30,6 @@ export type DeployProxyAdminResult = {
  * const { proxyAdmin } = await deployProxyAdmin({
  *   orbitChainWalletClient,
  * });
- * // proxyAdmin can now be passed straight into deployExpressLaneAuction
  */
 export async function deployProxyAdmin({
   orbitChainWalletClient,
@@ -50,13 +43,8 @@ export async function deployProxyAdmin({
     bytecode: proxyAdmin.bytecode as Hex,
   });
 
-  // Wait for the receipt to resolve the deployed address before returning, so the
-  // caller can feed it straight into deployExpressLaneAuction as the proxy admin.
   const receipt = await client.waitForTransactionReceipt({ hash: transactionHash });
 
-  // waitForTransactionReceipt does not reject on revert in this viem version, so a
-  // reverted deploy yields contractAddress: null; surface it with the tx hash instead
-  // of letting getAddress(null) throw an opaque InvalidAddressError.
   if (receipt.status === 'reverted' || !receipt.contractAddress) {
     throw new Error(
       `deployProxyAdmin: deployment transaction ${transactionHash} reverted (status=${receipt.status})`,

--- a/src/deployProxyAdmin.ts
+++ b/src/deployProxyAdmin.ts
@@ -1,0 +1,70 @@
+import { Address, Hex, WalletClient, getAddress, publicActions } from 'viem';
+
+import proxyAdmin from '@arbitrum/nitro-contracts/build/contracts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json';
+
+/**
+ * This type is for the params of the deployProxyAdmin function
+ */
+export type DeployProxyAdminParams = {
+  orbitChainWalletClient: WalletClient;
+};
+
+/**
+ * This type is for the result of the deployProxyAdmin function
+ */
+export type DeployProxyAdminResult = {
+  proxyAdmin: Address;
+  transactionHash: Hex;
+};
+
+/**
+ * Deploys an OpenZeppelin ProxyAdmin on the orbit (child) chain.
+ *
+ * The ProxyAdmin is the contract that owns and upgrades TransparentUpgradeableProxy instances.
+ * Its constructor takes no arguments; OZ's Ownable sets the owner to msg.sender, so the account
+ * behind orbitChainWalletClient becomes the ProxyAdmin owner.
+ *
+ * References:
+ * - ProxyAdmin contract: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v4.7/contracts/proxy/transparent/ProxyAdmin.sol
+ *
+ * @param {DeployProxyAdminParams} deployProxyAdminParams {@link DeployProxyAdminParams}
+ * @param {WalletClient} deployProxyAdminParams.orbitChainWalletClient - The orbit chain Viem wallet client (this account deploys the contract and becomes the ProxyAdmin owner)
+ *
+ * @returns Promise<DeployProxyAdminResult> {@link DeployProxyAdminResult} - The deployed ProxyAdmin address and the deployment transaction hash
+ *
+ * @example
+ * const { proxyAdmin } = await deployProxyAdmin({
+ *   orbitChainWalletClient,
+ * });
+ * // proxyAdmin can now be passed straight into deployExpressLaneAuction
+ */
+export async function deployProxyAdmin({
+  orbitChainWalletClient,
+}: DeployProxyAdminParams): Promise<DeployProxyAdminResult> {
+  const client = orbitChainWalletClient.extend(publicActions);
+
+  const transactionHash = await client.deployContract({
+    abi: proxyAdmin.abi,
+    account: orbitChainWalletClient.account!,
+    chain: orbitChainWalletClient.chain,
+    bytecode: proxyAdmin.bytecode as Hex,
+  });
+
+  // Wait for the receipt to resolve the deployed address before returning, so the
+  // caller can feed it straight into deployExpressLaneAuction as the proxy admin.
+  const receipt = await client.waitForTransactionReceipt({ hash: transactionHash });
+
+  // waitForTransactionReceipt does not reject on revert in this viem version, so a
+  // reverted deploy yields contractAddress: null; surface it with the tx hash instead
+  // of letting getAddress(null) throw an opaque InvalidAddressError.
+  if (receipt.status === 'reverted' || !receipt.contractAddress) {
+    throw new Error(
+      `deployProxyAdmin: deployment transaction ${transactionHash} reverted (status=${receipt.status})`,
+    );
+  }
+
+  return {
+    proxyAdmin: getAddress(receipt.contractAddress),
+    transactionHash,
+  };
+}

--- a/src/deployProxyAdmin.ts
+++ b/src/deployProxyAdmin.ts
@@ -23,13 +23,6 @@ export type DeployProxyAdminResult = {
  *
  * @param {DeployProxyAdminParams} deployProxyAdminParams {@link DeployProxyAdminParams}
  * @param {WalletClient} deployProxyAdminParams.orbitChainWalletClient - The orbit chain Viem wallet client (this account deploys the contract and becomes the ProxyAdmin owner)
- *
- * @returns Promise<DeployProxyAdminResult> {@link DeployProxyAdminResult} - The deployed ProxyAdmin address and the deployment transaction hash
- *
- * @example
- * const { proxyAdmin } = await deployProxyAdmin({
- *   orbitChainWalletClient,
- * });
  */
 export async function deployProxyAdmin({
   orbitChainWalletClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,17 @@ import {
   feeRouterDeployRewardDistributor,
   FeeRouterDeployRewardDistributorParams,
 } from './feeRouterDeployRewardDistributor';
+import {
+  deployProxyAdmin,
+  DeployProxyAdminParams,
+  DeployProxyAdminResult,
+} from './deployProxyAdmin';
+import {
+  deployExpressLaneAuction,
+  DeployExpressLaneAuctionParams,
+  DeployExpressLaneAuctionResult,
+  ExpressLaneAuctionRoundTimingInfo,
+} from './deployExpressLaneAuction';
 import * as utils from './utils';
 
 import { getBridgeUiConfig, GetBridgeUiConfigFunctionParams } from './getBridgeUiConfig';
@@ -297,6 +308,13 @@ export {
   FeeRouterDeployChildToParentRewardRouterParams,
   feeRouterDeployRewardDistributor,
   FeeRouterDeployRewardDistributorParams,
+  deployProxyAdmin,
+  DeployProxyAdminParams,
+  DeployProxyAdminResult,
+  deployExpressLaneAuction,
+  DeployExpressLaneAuctionParams,
+  DeployExpressLaneAuctionResult,
+  ExpressLaneAuctionRoundTimingInfo,
   //
   getDefaultConfirmPeriodBlocks,
   getDefaultChallengeGracePeriodBlocks,

--- a/src/package.json
+++ b/src/package.json
@@ -57,6 +57,7 @@
     "viem": "^1.20.0"
   },
   "dependencies": {
+    "@arbitrum/nitro-contracts": "^3.2.0",
     "@arbitrum/sdk": "^4.0.4",
     "@arbitrum/token-bridge-contracts": "^1.2.2",
     "@ethersproject/abstract-provider": "^5.7.0",

--- a/src/scripting/commands.ts
+++ b/src/scripting/commands.ts
@@ -25,6 +25,8 @@ import {
   createTokenBridgePrepareCustomFeeTokenApprovalTransactionRequestSchema,
   feeRouterDeployRewardDistributorSchema,
   feeRouterDeployChildToParentRewardRouterSchema,
+  deployProxyAdminSchema,
+  deployExpressLaneAuctionSchema,
   prepareChainConfigParamsSchema,
   prepareNodeConfigSchema,
   prepareKeysetSchema,
@@ -79,6 +81,8 @@ import { createTokenBridgeEnoughCustomFeeTokenAllowance } from '../createTokenBr
 import { createTokenBridgePrepareCustomFeeTokenApprovalTransactionRequest } from '../createTokenBridgePrepareCustomFeeTokenApprovalTransactionRequest';
 import { feeRouterDeployRewardDistributor } from '../feeRouterDeployRewardDistributor';
 import { feeRouterDeployChildToParentRewardRouter } from '../feeRouterDeployChildToParentRewardRouter';
+import { deployProxyAdmin } from '../deployProxyAdmin';
+import { deployExpressLaneAuction } from '../deployExpressLaneAuction';
 import { prepareChainConfig } from '../prepareChainConfig';
 import { prepareNodeConfig } from '../prepareNodeConfig';
 import { prepareKeyset } from '../prepareKeyset';
@@ -274,6 +278,8 @@ export const commands: readonly Command[] = [
     feeRouterDeployChildToParentRewardRouterSchema,
     feeRouterDeployChildToParentRewardRouter,
   ),
+  command('deployProxyAdmin', deployProxyAdminSchema, deployProxyAdmin),
+  command('deployExpressLaneAuction', deployExpressLaneAuctionSchema, deployExpressLaneAuction),
   command('prepareChainConfig', prepareChainConfigParamsSchema, prepareChainConfig),
   command('prepareNodeConfig', prepareNodeConfigSchema, prepareNodeConfig),
   command('prepareKeyset', prepareKeysetSchema, prepareKeyset),

--- a/src/scripting/contractCommand.unit.test.ts
+++ b/src/scripting/contractCommand.unit.test.ts
@@ -33,6 +33,7 @@ const __viemMocks = vi.hoisted(() => {
 vi.mock('./viemTransforms', () => ({
   toPublicClient: () => __viemMocks.mockClient,
   findChain: (id: number) => ({ id }),
+  findOrDefineChain: (id: number) => ({ id }),
 }));
 
 beforeEach(() => {

--- a/src/scripting/runContractCommand.ts
+++ b/src/scripting/runContractCommand.ts
@@ -4,7 +4,7 @@ import { formatAbiItem } from 'viem/utils';
 import type { AbiFunction } from 'abitype';
 
 import { upgradeExecutorABI } from '../contracts/UpgradeExecutor';
-import { toPublicClient, findChain } from './viemTransforms';
+import { toPublicClient, findOrDefineChain } from './viemTransforms';
 
 export type ParsedContractCommand = {
   rpcUrl: string;
@@ -32,7 +32,7 @@ export async function runContractCommand({
   parsed: ParsedContractCommand;
 }): Promise<unknown> {
   const fn = findAbiFunction(abi, parsed.function);
-  const client = toPublicClient(parsed.rpcUrl, findChain(parsed.chainId));
+  const client = toPublicClient(parsed.rpcUrl, findOrDefineChain(parsed.chainId, parsed.rpcUrl));
 
   if (fn.stateMutability === 'view' || fn.stateMutability === 'pure') {
     return client.readContract({

--- a/src/scripting/schemaCoverage.ts
+++ b/src/scripting/schemaCoverage.ts
@@ -370,6 +370,10 @@ vi.mock('../feeRouterDeployRewardDistributor', () => ({
 vi.mock('../feeRouterDeployChildToParentRewardRouter', () => ({
   feeRouterDeployChildToParentRewardRouter: _mocks.fn('feeRouterDeployChildToParentRewardRouter'),
 }));
+vi.mock('../deployProxyAdmin', () => ({ deployProxyAdmin: _mocks.fn('deployProxyAdmin') }));
+vi.mock('../deployExpressLaneAuction', () => ({
+  deployExpressLaneAuction: _mocks.fn('deployExpressLaneAuction'),
+}));
 vi.mock('../prepareNodeConfig', () => ({ prepareNodeConfig: _mocks.fn('prepareNodeConfig') }));
 vi.mock('../getDefaultConfirmPeriodBlocks', () => ({
   getDefaultConfirmPeriodBlocks: _mocks.fn('getDefaultConfirmPeriodBlocks'),

--- a/src/scripting/schemas/deployProxyAdmin.ts
+++ b/src/scripting/schemas/deployProxyAdmin.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { withChildChainSign } from '../viemTransforms';
+import { privateKeySchema } from './common';
+
+export const deployProxyAdminSchema = z
+  .strictObject({
+    orbitChainRpcUrl: z.url(),
+    orbitChainId: z.number(),
+    privateKey: privateKeySchema,
+  })
+  .transform(withChildChainSign);

--- a/src/scripting/schemas/expressLaneAuction.ts
+++ b/src/scripting/schemas/expressLaneAuction.ts
@@ -2,14 +2,6 @@ import { z } from 'zod';
 import { withChildChainSign } from '../viemTransforms';
 import { addressSchema, bigintSchema, privateKeySchema } from './common';
 
-export const deployProxyAdminSchema = z
-  .strictObject({
-    orbitChainRpcUrl: z.url(),
-    orbitChainId: z.number(),
-    privateKey: privateKeySchema,
-  })
-  .transform(withChildChainSign);
-
 export const deployExpressLaneAuctionSchema = z
   .strictObject({
     orbitChainRpcUrl: z.url(),

--- a/src/scripting/schemas/expressLaneAuction.ts
+++ b/src/scripting/schemas/expressLaneAuction.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { withChildChainSign } from '../viemTransforms';
+import { addressSchema, bigintSchema, privateKeySchema } from './common';
+
+export const deployProxyAdminSchema = z
+  .strictObject({
+    orbitChainRpcUrl: z.url(),
+    orbitChainId: z.number(),
+    privateKey: privateKeySchema,
+  })
+  .transform(withChildChainSign);
+
+export const deployExpressLaneAuctionSchema = z
+  .strictObject({
+    orbitChainRpcUrl: z.url(),
+    orbitChainId: z.number(),
+    privateKey: privateKeySchema,
+    proxyAdmin: addressSchema,
+    auctioneer: addressSchema,
+    biddingToken: addressSchema,
+    beneficiary: addressSchema,
+    roundTimingInfo: z.strictObject({
+      offsetTimestamp: bigintSchema,
+      roundDurationSeconds: bigintSchema,
+      auctionClosingSeconds: bigintSchema,
+      reserveSubmissionSeconds: bigintSchema,
+    }),
+    minReservePrice: bigintSchema,
+    auctioneerAdmin: addressSchema,
+    minReservePriceSetter: addressSchema,
+    reservePriceSetter: addressSchema,
+    reservePriceSetterAdmin: addressSchema,
+    beneficiarySetter: addressSchema,
+    roundTimingSetter: addressSchema,
+    masterAdmin: addressSchema,
+  })
+  .transform(withChildChainSign);

--- a/src/scripting/schemas/index.ts
+++ b/src/scripting/schemas/index.ts
@@ -34,7 +34,8 @@ export {
   feeRouterDeployRewardDistributorSchema,
   feeRouterDeployChildToParentRewardRouterSchema,
 } from './feeRouter';
-export { deployProxyAdminSchema, deployExpressLaneAuctionSchema } from './expressLaneAuction';
+export { deployProxyAdminSchema } from './deployProxyAdmin';
+export { deployExpressLaneAuctionSchema } from './expressLaneAuction';
 export { getBridgeUiConfigSchema } from './getBridgeUiConfig';
 export { isAnyTrustSchema } from './isAnyTrust';
 export { createRollupFetchTransactionHashSchema } from './createRollupFetchTransactionHash';

--- a/src/scripting/schemas/index.ts
+++ b/src/scripting/schemas/index.ts
@@ -34,6 +34,7 @@ export {
   feeRouterDeployRewardDistributorSchema,
   feeRouterDeployChildToParentRewardRouterSchema,
 } from './feeRouter';
+export { deployProxyAdminSchema, deployExpressLaneAuctionSchema } from './expressLaneAuction';
 export { getBridgeUiConfigSchema } from './getBridgeUiConfig';
 export { isAnyTrustSchema } from './isAnyTrust';
 export { createRollupFetchTransactionHashSchema } from './createRollupFetchTransactionHash';

--- a/src/scripting/viemTransforms.ts
+++ b/src/scripting/viemTransforms.ts
@@ -13,11 +13,6 @@ export function findChain(chainId: number): Chain {
   return chain;
 }
 
-// Resolve a chain for CLI use, preferring the rich known/registered Chain (it carries
-// multicall3, native currency and explorer metadata). When the id isn't recognised --
-// e.g. a freshly deployed orbit chain that isn't in the registry -- synthesize a minimal
-// chain from the id and RPC instead of throwing. Only the id matters for EIP-155 signing,
-// and the transport always uses the supplied rpcUrl, so this is enough to deploy/read.
 export function findOrDefineChain(chainId: number, rpcUrl: string): Chain {
   const knownChains = [...chains, ...getCustomParentChains()];
   const chain = knownChains.find((c) => c.id === chainId);

--- a/src/scripting/viemTransforms.ts
+++ b/src/scripting/viemTransforms.ts
@@ -1,4 +1,4 @@
-import { Chain, createPublicClient, createWalletClient, http } from 'viem';
+import { Chain, createPublicClient, createWalletClient, defineChain, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { sanitizePrivateKey } from '../utils/sanitizePrivateKey';
 import { chains, getCustomParentChains } from '../chains';
@@ -11,6 +11,24 @@ export function findChain(chainId: number): Chain {
     throw new Error(`Unknown chain ID: ${chainId}. Known chain IDs: ${known}`);
   }
   return chain;
+}
+
+// Resolve a chain for CLI use, preferring the rich known/registered Chain (it carries
+// multicall3, native currency and explorer metadata). When the id isn't recognised --
+// e.g. a freshly deployed orbit chain that isn't in the registry -- synthesize a minimal
+// chain from the id and RPC instead of throwing. Only the id matters for EIP-155 signing,
+// and the transport always uses the supplied rpcUrl, so this is enough to deploy/read.
+export function findOrDefineChain(chainId: number, rpcUrl: string): Chain {
+  const knownChains = [...chains, ...getCustomParentChains()];
+  const chain = knownChains.find((c) => c.id === chainId);
+  if (chain) return chain;
+  return defineChain({
+    id: chainId,
+    name: `Chain ${chainId}`,
+    network: `chain-${chainId}`,
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    rpcUrls: { default: { http: [rpcUrl] }, public: { http: [rpcUrl] } },
+  });
 }
 
 export function toPublicClient<TChain extends Chain | undefined = undefined>(
@@ -129,7 +147,11 @@ export function withChildChainSign<
   const { orbitChainRpcUrl, orbitChainId, privateKey, ...rest } = input;
   return [
     {
-      orbitChainWalletClient: toWalletClient(orbitChainRpcUrl, privateKey, findChain(orbitChainId)),
+      orbitChainWalletClient: toWalletClient(
+        orbitChainRpcUrl,
+        privateKey,
+        findOrDefineChain(orbitChainId, orbitChainRpcUrl),
+      ),
       ...rest,
     },
   ] as WithChildChainSign<T>;


### PR DESCRIPTION
- Add `deployProxyAdmin`: deploys an OpenZeppelin ProxyAdmin on the orbit chain (owned by the deployer).
- Add `deployExpressLaneAuction`: deploys the Timeboost ExpressLaneAuction implementation and an initialized TransparentUpgradeableProxy in front of it, given a ProxyAdmin.
- Expose both as CLI commands (`deployProxyAdmin`, `deployExpressLaneAuction`).
- Add `@arbitrum/nitro-contracts@^3.2.0` as the source of the contract ABIs/bytecode.
- CLI: resolve unrecognised orbit chain ids via a `defineChain` fallback (`withChildChainSign` + contract commands), so child-chain commands work on chains not in the registry.