### PR TITLE
feat: add consensus v61 (ArbOS 61) support

### DIFF
--- a/src/wasmModuleRoot.ts
+++ b/src/wasmModuleRoot.ts
@@ -93,6 +93,12 @@ const consensusReleases = [
     wasmModuleRoot: '0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c',
     maxArbOSVersion: 51,
   },
+  {
+    // https://github.com/OffchainLabs/nitro/releases/tag/consensus-v61
+    version: 61,
+    wasmModuleRoot: '0xc10cd7ec6acaf1c441a3f6bd0900ad20f15855ba775a96f1939118cbc629dc97',
+    maxArbOSVersion: 61,
+  },
 ] as const satisfies readonly ConsensusRelease[];
 
 type ConsensusReleases = typeof consensusReleases;


### PR DESCRIPTION
## Summary

Adds consensus v61 (ArbOS 61) support to the SDK and makes ArbOS 61 the default `InitialArbOSVersion`.

This supersedes #719 (which added v60). **v60 is intentionally skipped in the SDK.**

## Pinned to a release candidate

The WASM module root points at the **pre-release** `consensus-v61-rc.2`:

```
0xc10cd7ec6acaf1c441a3f6bd0900ad20f15855ba775a96f1939118cbc629dc97
```

**This must be updated to the final `consensus-v61` release root once it ships.** Tracking item: bump the v61 `wasmModuleRoot` and the comment URL in `src/wasmModuleRoot.ts` when the final release lands.

Release: https://github.com/OffchainLabs/nitro/releases/tag/consensus-v61-rc.2

## Notes

- #719 will be closed in favour of this PR. The `feat/consensus-v60-arbos60` branch is left intact.
