### PR TITLE
feat: update fund distribution contracts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       '@offchainlabs/fund-distribution-contracts':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.1.0
+        version: 1.1.0
       '@safe-global/protocol-kit':
         specifier: ^4.1.7
         version: 4.1.7(typescript@5.2.2)(zod@4.3.6)
@@ -878,8 +878,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@offchainlabs/fund-distribution-contracts@1.0.1':
-    resolution: {integrity: sha512-ig1aAmfWPpq9474td6M/f/ltseipM2c5xs3nAsv9JX6YBhRF4OlNBczfdtjTgEh069rCnu4DcFSdoNzuaHDxBg==}
+  '@offchainlabs/fund-distribution-contracts@1.1.0':
+    resolution: {integrity: sha512-tSD0cMJ1q1cjKawfeDc+Rg2x5ezi1eSDikFt5nzDcqETcfTk2Z6dzMV1UQgDdgVuMxmdaO57OAkqdNrtGXXRxA==}
 
   '@offchainlabs/prettier-config@0.2.1':
     resolution: {integrity: sha512-VjE4Hahx9ipTheXJVlt7tFtHeMVvlYUkKNT4uxnAK4i4qrLcqhlm/4GE9mueOS/Syi2/gzDKvNH0nk6+ts2IrA==}
@@ -1106,12 +1106,6 @@ packages:
 
   '@types/secp256k1@4.0.6':
     resolution: {integrity: sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==}
-
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@17.0.32':
-    resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -3572,11 +3566,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  '@offchainlabs/fund-distribution-contracts@1.0.1':
-    dependencies:
-      '@types/yargs': 17.0.32
-      dotenv: 16.3.1
-      yargs: 17.7.2
+  '@offchainlabs/fund-distribution-contracts@1.1.0': {}
 
   '@offchainlabs/prettier-config@0.2.1(prettier@2.8.8)':
     dependencies:
@@ -3769,12 +3759,6 @@ snapshots:
   '@types/secp256k1@4.0.6':
     dependencies:
       '@types/node': 20.9.0
-
-  '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@17.0.32':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.2.2))(eslint@9.39.3)(typescript@5.2.2)':
     dependencies:

--- a/src/feeRouter.integration.test.ts
+++ b/src/feeRouter.integration.test.ts
@@ -8,6 +8,7 @@ import {
   encodePacked,
   keccak256,
   pad,
+  zeroAddress,
 } from 'viem';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
@@ -95,6 +96,12 @@ describe('Fee routing tests', () => {
       rewardDistributorDeploymentTransactionReceipt.contractAddress as `0x${string}`,
     );
 
+    const token = await nitroTestnodeL2Client.readContract({
+      address: rewardDistributorAddress,
+      abi: parseAbi(['function token() view returns (address)']),
+      functionName: 'token',
+    });
+
     // hashing the recipient addresses
     // keccak256(abi.encodePacked(addresses))
     // Note: we need to pad the addresses to 32-bytes, since the packing in Solidity is done that way
@@ -129,6 +136,7 @@ describe('Fee routing tests', () => {
       functionName: 'currentRecipientWeights',
     });
 
+    expect(token).toEqual(zeroAddress);
     expect(currentRecipientGroup).toEqual(recipientGroup);
     expect(currentRecipientWeights).toEqual(recipientWeights);
   });

--- a/src/feeRouterDeployRewardDistributor.ts
+++ b/src/feeRouterDeployRewardDistributor.ts
@@ -1,4 +1,4 @@
-import { Address, WalletClient } from 'viem';
+import { Address, WalletClient, zeroAddress } from 'viem';
 
 import rewardDistributor from '@offchainlabs/fund-distribution-contracts/out/RewardDistributor.sol/RewardDistributor.json';
 
@@ -15,6 +15,7 @@ export type RewardDistributorRecipient = {
  */
 export type FeeRouterDeployRewardDistributorParams = {
   orbitChainWalletClient: WalletClient;
+  token?: Address;
   recipients: RewardDistributorRecipient[];
 };
 
@@ -32,6 +33,7 @@ export type FeeRouterDeployRewardDistributorParams = {
  *
  * @param {FeeRouterDeployRewardDistributorParams} feeRouterDeployRewardDistributorParams {@link FeeRouterDeployRewardDistributorParams}
  * @param {WalletClient} feeRouterDeployRewardDistributorParams.orbitChainWalletClient - The orbit chain Viem wallet client (this account will deploy the contract)
+ * @param {Address} feeRouterDeployRewardDistributorParams.token - [Optional] The token to distribute. Defaults to the native token.
  * @param {RewardDistributorRecipient[]} feeRouterDeployRewardDistributorParams.recipients - The recipients of the rewards (array objects with properties "account" and "weight") {@link RewardDistributorRecipient}
  * @param {Address} feeRouterDeployRewardDistributorParams.recipients.account - Recipient of rewards
  * @param {Address} feeRouterDeployRewardDistributorParams.recipients.weight - Percentage of the reward obtained multiplied by 100 (e.g., for obtaining 25%, the weight would be 2500)
@@ -63,6 +65,7 @@ export type FeeRouterDeployRewardDistributorParams = {
  */
 export async function feeRouterDeployRewardDistributor({
   orbitChainWalletClient,
+  token = zeroAddress,
   recipients,
 }: FeeRouterDeployRewardDistributorParams) {
   const transactionHash = await orbitChainWalletClient.deployContract({
@@ -70,6 +73,7 @@ export async function feeRouterDeployRewardDistributor({
     account: orbitChainWalletClient.account!,
     chain: orbitChainWalletClient.chain,
     args: [
+      token,
       recipients.map((recipient) => recipient.account),
       recipients.map((recipient) => recipient.weight),
     ],

--- a/src/package.json
+++ b/src/package.json
@@ -61,7 +61,7 @@
     "@arbitrum/token-bridge-contracts": "^1.2.2",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@offchainlabs/fund-distribution-contracts": "^1.0.1",
+    "@offchainlabs/fund-distribution-contracts": "^1.1.0",
     "@safe-global/protocol-kit": "^4.1.7",
     "abitype": "^0.9.8",
     "ethers": "^5.7.2",

--- a/src/scripting/schemas/feeRouter.ts
+++ b/src/scripting/schemas/feeRouter.ts
@@ -17,6 +17,7 @@ export const feeRouterDeployRewardDistributorSchema = z
     orbitChainRpcUrl: z.url(),
     orbitChainId: z.number(),
     privateKey: privateKeySchema,
+    token: addressSchema.optional(),
     recipients: z.array(recipientSchema),
   })
   .transform(withChildChainSign);


### PR DESCRIPTION
## Summary
- Update `@offchainlabs/fund-distribution-contracts` from `^1.0.1` to `^1.1.0`.
- Refresh `pnpm-lock.yaml` so the SDK resolves the `1.1.0` package and drops transitive dependencies that are no longer present.
- Keep the existing router import paths and deploy code unchanged because the `ArbChildToParentRewardRouter` and `OpChildToParentRewardRouter` constructor ABIs are unchanged in `1.1.0`.

## Why / Context
- `fund-distribution-contracts@1.1.0` publishes updated router artifacts for `ArbChildToParentRewardRouter` and `OpChildToParentRewardRouter`.
- The published `1.1.0` package `gitHead` matches the latest `fund-distribution-contracts` `main` commit: `6f2eed33e999d92530d07da10c48f9f733a31c33`.
- The published router sources match the contract repo `main` sources, and locally rebuilt router artifacts match the npm package artifacts by ABI and bytecode hash.
