### PR TITLE
chore: bump version

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
   - "examples/*"
 
 minimumReleaseAge: 10080 # 7 days
+minimumReleaseAgeExclude:
+  - '@offchainlabs/fund-distribution-contracts'
 
 # Dependency overrides. Most are security pins that force a vulnerable transitive
 # up to a patched version (audit:ci fails on any advisory >= low). They live here,

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arbitrum/chain-sdk",
   "description": "TypeScript SDK for building Arbitrum chains",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "main": "./dist/index.js",
   "bin": {
     "arbitrum-chain-sdk": "./dist/scripting/cli.js"


### PR DESCRIPTION
## Summary
- Bumps `@arbitrum/chain-sdk` from `0.26.0` to `0.27.0`.

## Why / Context
- Prepares the next chain-sdk package release.