### PR TITLE
refactor: deduplicate tx request preparation

### DIFF
--- a/src/actions/buildInvalidateKeysetHash.ts
+++ b/src/actions/buildInvalidateKeysetHash.ts
@@ -1,4 +1,4 @@
-import { Chain, Hex, PrepareTransactionRequestParameters, PublicClient, Transport } from 'viem';
+import { Chain, Hex, PublicClient, Transport } from 'viem';
 import { sequencerInboxABI } from '../contracts/SequencerInbox';
 import {
   ActionParameters,
@@ -8,7 +8,7 @@ import {
 } from '../types/Actions';
 import { Prettify } from '../types/utils';
 import { validateParentChain } from '../types/ParentChain';
-import { prepareUpgradeExecutorCallParameters } from '../prepareUpgradeExecutorCallParameters';
+import { prepareContractTransactionRequest } from '../contractTransactionRequests';
 
 export type BuildInvalidateKeysetHashParameters<Curried extends boolean = false> = Prettify<
   WithUpgradeExecutor<
@@ -37,17 +37,13 @@ export async function buildInvalidateKeysetHash<TChain extends Chain | undefined
 ): Promise<BuildInvalidateKeysetHashReturnType> {
   const { chainId } = validateParentChain(client);
 
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
+  return prepareContractTransactionRequest(client, {
+    chainId,
     account,
-    ...prepareUpgradeExecutorCallParameters({
-      to: sequencerInboxAddress,
-      upgradeExecutor,
-      args: [params.keysetHash],
-      abi: sequencerInboxABI,
-      functionName: 'invalidateKeysetHash',
-    }),
-  } satisfies PrepareTransactionRequestParameters);
-
-  return { ...request, chainId };
+    to: sequencerInboxAddress,
+    upgradeExecutor,
+    args: [params.keysetHash],
+    abi: sequencerInboxABI,
+    functionName: 'invalidateKeysetHash',
+  });
 }

--- a/src/actions/buildSetAllowList.ts
+++ b/src/actions/buildSetAllowList.ts
@@ -1,4 +1,4 @@
-import { Address, Chain, PrepareTransactionRequestParameters, PublicClient, Transport } from 'viem';
+import { Address, Chain, PublicClient, Transport } from 'viem';
 import { inboxABI } from '../contracts/Inbox';
 import {
   ActionParameters,
@@ -7,7 +7,7 @@ import {
   WithUpgradeExecutor,
 } from '../types/Actions';
 import { Prettify } from '../types/utils';
-import { prepareUpgradeExecutorCallParameters } from '../prepareUpgradeExecutorCallParameters';
+import { prepareContractTransactionRequest } from '../contractTransactionRequests';
 import { validateParentChain } from '../types/ParentChain';
 
 type Args = {
@@ -27,17 +27,13 @@ export async function buildSetAllowList<TChain extends Chain | undefined>(
 ): Promise<BuildSetAllowListReturnType> {
   const { chainId } = validateParentChain(client);
 
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
+  return prepareContractTransactionRequest(client, {
+    chainId,
     account,
-    ...prepareUpgradeExecutorCallParameters({
-      to: inboxAddress,
-      upgradeExecutor,
-      args: [params.addresses, params.allowed],
-      abi: inboxABI,
-      functionName: 'setAllowList',
-    }),
-  } satisfies PrepareTransactionRequestParameters);
-
-  return { ...request, chainId };
+    to: inboxAddress,
+    upgradeExecutor,
+    args: [params.addresses, params.allowed],
+    abi: inboxABI,
+    functionName: 'setAllowList',
+  });
 }

--- a/src/actions/buildSetAllowListEnabled.ts
+++ b/src/actions/buildSetAllowListEnabled.ts
@@ -1,4 +1,4 @@
-import { Chain, PrepareTransactionRequestParameters, PublicClient, Transport } from 'viem';
+import { Chain, PublicClient, Transport } from 'viem';
 import { inboxABI } from '../contracts/Inbox';
 import {
   ActionParameters,
@@ -7,7 +7,7 @@ import {
   WithUpgradeExecutor,
 } from '../types/Actions';
 import { Prettify } from '../types/utils';
-import { prepareUpgradeExecutorCallParameters } from '../prepareUpgradeExecutorCallParameters';
+import { prepareContractTransactionRequest } from '../contractTransactionRequests';
 import { validateParentChain } from '../types/ParentChain';
 
 type Args = {
@@ -26,17 +26,13 @@ export async function buildSetAllowListEnabled<TChain extends Chain | undefined>
 ): Promise<BuildSetAllowListEnabledReturnType> {
   const { chainId } = validateParentChain(client);
 
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
+  return prepareContractTransactionRequest(client, {
+    chainId,
     account,
-    ...prepareUpgradeExecutorCallParameters({
-      to: inboxAddress,
-      upgradeExecutor,
-      args: [params.enabled],
-      abi: inboxABI,
-      functionName: 'setAllowListEnabled',
-    }),
-  } satisfies PrepareTransactionRequestParameters);
-
-  return { ...request, chainId };
+    to: inboxAddress,
+    upgradeExecutor,
+    args: [params.enabled],
+    abi: inboxABI,
+    functionName: 'setAllowListEnabled',
+  });
 }

--- a/src/actions/buildSetIsBatchPoster.ts
+++ b/src/actions/buildSetIsBatchPoster.ts
@@ -1,4 +1,4 @@
-import { Address, Chain, PrepareTransactionRequestParameters, PublicClient, Transport } from 'viem';
+import { Address, Chain, PublicClient, Transport } from 'viem';
 import { sequencerInboxABI } from '../contracts/SequencerInbox';
 import {
   ActionParameters,
@@ -7,7 +7,7 @@ import {
   WithUpgradeExecutor,
 } from '../types/Actions';
 import { Prettify } from '../types/utils';
-import { prepareUpgradeExecutorCallParameters } from '../prepareUpgradeExecutorCallParameters';
+import { prepareContractTransactionRequest } from '../contractTransactionRequests';
 import { validateParentChain } from '../types/ParentChain';
 
 type Args = {
@@ -31,19 +31,15 @@ export async function buildSetIsBatchPoster<TChain extends Chain | undefined>(
 ): Promise<BuildSetIsBatchPosterReturnType> {
   const { chainId } = validateParentChain(client);
 
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
+  return prepareContractTransactionRequest(client, {
+    chainId,
     account,
-    ...prepareUpgradeExecutorCallParameters({
-      to: sequencerInboxAddress,
-      upgradeExecutor,
-      args: [params.batchPoster, params.enable],
-      abi: sequencerInboxABI,
-      functionName: 'setIsBatchPoster',
-    }),
-  } satisfies PrepareTransactionRequestParameters);
-
-  return { ...request, chainId };
+    to: sequencerInboxAddress,
+    upgradeExecutor,
+    args: [params.batchPoster, params.enable],
+    abi: sequencerInboxABI,
+    functionName: 'setIsBatchPoster',
+  });
 }
 
 export async function buildEnableBatchPoster<TChain extends Chain | undefined>(

--- a/src/actions/buildSetMaxTimeVariation.ts
+++ b/src/actions/buildSetMaxTimeVariation.ts
@@ -1,4 +1,4 @@
-import { Chain, PrepareTransactionRequestParameters, PublicClient, Transport } from 'viem';
+import { Chain, PublicClient, Transport } from 'viem';
 import { sequencerInboxABI } from '../contracts/SequencerInbox';
 import {
   ActionParameters,
@@ -7,7 +7,7 @@ import {
   WithUpgradeExecutor,
 } from '../types/Actions';
 import { Prettify } from '../types/utils';
-import { prepareUpgradeExecutorCallParameters } from '../prepareUpgradeExecutorCallParameters';
+import { prepareContractTransactionRequest } from '../contractTransactionRequests';
 import { validateParentChain } from '../types/ParentChain';
 
 type Args = {
@@ -33,17 +33,13 @@ export async function buildSetMaxTimeVariation<TChain extends Chain | undefined>
 ): Promise<BuildSetMaxTimeVariationReturnType> {
   const { chainId } = validateParentChain(client);
 
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
+  return prepareContractTransactionRequest(client, {
+    chainId,
     account,
-    ...prepareUpgradeExecutorCallParameters({
-      to: sequencerInboxAddress,
-      upgradeExecutor,
-      args: [params],
-      abi: sequencerInboxABI,
-      functionName: 'setMaxTimeVariation',
-    }),
-  } satisfies PrepareTransactionRequestParameters);
-
-  return { ...request, chainId };
+    to: sequencerInboxAddress,
+    upgradeExecutor,
+    args: [params],
+    abi: sequencerInboxABI,
+    functionName: 'setMaxTimeVariation',
+  });
 }

--- a/src/actions/buildSetValidKeyset.ts
+++ b/src/actions/buildSetValidKeyset.ts
@@ -1,4 +1,4 @@
-import { Chain, Hex, PrepareTransactionRequestParameters, PublicClient, Transport } from 'viem';
+import { Chain, Hex, PublicClient, Transport } from 'viem';
 import { sequencerInboxABI } from '../contracts/SequencerInbox';
 import {
   ActionParameters,
@@ -8,7 +8,7 @@ import {
 } from '../types/Actions';
 import { Prettify } from '../types/utils';
 import { validateParentChain } from '../types/ParentChain';
-import { prepareUpgradeExecutorCallParameters } from '../prepareUpgradeExecutorCallParameters';
+import { prepareContractTransactionRequest } from '../contractTransactionRequests';
 
 export type BuildSetValidKeysetParameters<Curried extends boolean = false> = Prettify<
   WithUpgradeExecutor<
@@ -37,17 +37,13 @@ export async function buildSetValidKeyset<TChain extends Chain | undefined>(
 ): Promise<BuildSetValidKeysetReturnType> {
   const { chainId } = validateParentChain(client);
 
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
+  return prepareContractTransactionRequest(client, {
+    chainId,
     account,
-    ...prepareUpgradeExecutorCallParameters({
-      to: sequencerInboxAddress,
-      upgradeExecutor,
-      args: [params.keyset],
-      abi: sequencerInboxABI,
-      functionName: 'setValidKeyset',
-    }),
-  } satisfies PrepareTransactionRequestParameters);
-
-  return { ...request, chainId };
+    to: sequencerInboxAddress,
+    upgradeExecutor,
+    args: [params.keyset],
+    abi: sequencerInboxABI,
+    functionName: 'setValidKeyset',
+  });
 }

--- a/src/arbAggregatorPrepareTransactionRequest.ts
+++ b/src/arbAggregatorPrepareTransactionRequest.ts
@@ -1,31 +1,18 @@
-import {
-  PublicClient,
-  encodeFunctionData,
-  EncodeFunctionDataParameters,
-  Address,
-  Chain,
-  Transport,
-} from 'viem';
+import { PublicClient, Address, Chain, Transport } from 'viem';
 
 import { arbAggregatorABI, arbAggregatorAddress } from './contracts/ArbAggregator';
-import { upgradeExecutorEncodeFunctionData } from './upgradeExecutorEncodeFunctionData';
 import { GetFunctionName } from './types/utils';
+import {
+  ContractEncodeFunctionDataParameters,
+  prepareContractCallParameters,
+  prepareContractTransactionRequest,
+} from './contractTransactionRequests';
 
 type ArbAggregatorAbi = typeof arbAggregatorABI;
 export type ArbAggregatorPrepareTransactionRequestFunctionName = GetFunctionName<ArbAggregatorAbi>;
 export type ArbAggregatorEncodeFunctionDataParameters<
   TFunctionName extends ArbAggregatorPrepareTransactionRequestFunctionName,
-> = EncodeFunctionDataParameters<ArbAggregatorAbi, TFunctionName>;
-
-function arbAggregatorEncodeFunctionData<
-  TFunctionName extends ArbAggregatorPrepareTransactionRequestFunctionName,
->({ functionName, abi, args }: ArbAggregatorEncodeFunctionDataParameters<TFunctionName>) {
-  return encodeFunctionData({
-    abi,
-    functionName,
-    args,
-  });
-}
+> = ContractEncodeFunctionDataParameters<ArbAggregatorAbi, TFunctionName>;
 
 export type ArbAggregatorPrepareFunctionDataParameters<
   TFunctionName extends ArbAggregatorPrepareTransactionRequestFunctionName,
@@ -37,31 +24,10 @@ export type ArbAggregatorPrepareFunctionDataParameters<
 export function arbAggregatorPrepareFunctionData<
   TFunctionName extends ArbAggregatorPrepareTransactionRequestFunctionName,
 >(params: ArbAggregatorPrepareFunctionDataParameters<TFunctionName>) {
-  const { upgradeExecutor } = params;
-
-  if (!upgradeExecutor) {
-    return {
-      to: arbAggregatorAddress,
-      data: arbAggregatorEncodeFunctionData(
-        params as ArbAggregatorEncodeFunctionDataParameters<TFunctionName>,
-      ),
-      value: BigInt(0),
-    };
-  }
-
-  return {
-    to: upgradeExecutor,
-    data: upgradeExecutorEncodeFunctionData({
-      functionName: 'executeCall',
-      args: [
-        arbAggregatorAddress, // target
-        arbAggregatorEncodeFunctionData(
-          params as ArbAggregatorEncodeFunctionDataParameters<TFunctionName>,
-        ), // targetCallData
-      ],
-    }),
-    value: BigInt(0),
-  };
+  return prepareContractCallParameters({
+    ...params,
+    to: arbAggregatorAddress,
+  });
 }
 
 export type ArbAggregatorPrepareTransactionRequestParameters<
@@ -80,20 +46,13 @@ export async function arbAggregatorPrepareTransactionRequest<
     throw new Error('[arbAggregatorPrepareTransactionRequest] client.chain is undefined');
   }
 
-  // params is extending ArbAggregatorPrepareFunctionDataParameters, it's safe to cast
-  const { to, data, value } = arbAggregatorPrepareFunctionData({
-    ...params,
-    abi: arbAggregatorABI,
-  } as unknown as ArbAggregatorPrepareFunctionDataParameters<TFunctionName>);
-
-  // @ts-expect-error -- todo: fix viem type issue
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
-    to,
-    data,
-    value,
-    account: params.account,
-  });
-
-  return { ...request, chainId: client.chain.id };
+  return prepareContractTransactionRequest<ArbAggregatorAbi, TFunctionName, Transport, TChain>(
+    client,
+    {
+      ...params,
+      abi: arbAggregatorABI,
+      to: arbAggregatorAddress,
+      chainId: client.chain.id,
+    },
+  );
 }

--- a/src/arbOwnerPrepareTransactionRequest.ts
+++ b/src/arbOwnerPrepareTransactionRequest.ts
@@ -1,32 +1,19 @@
-import {
-  PublicClient,
-  encodeFunctionData,
-  EncodeFunctionDataParameters,
-  Address,
-  Chain,
-  Transport,
-} from 'viem';
+import { PublicClient, Address, Chain, Transport } from 'viem';
 
 import { arbOwnerABI, arbOwnerAddress } from './contracts/ArbOwner';
-import { upgradeExecutorEncodeFunctionData } from './upgradeExecutorEncodeFunctionData';
 import { GetFunctionName } from './types/utils';
 import { TransactionRequestGasOverrides, applyPercentIncrease } from './utils/gasOverrides';
+import {
+  ContractEncodeFunctionDataParameters,
+  prepareContractCallParameters,
+  prepareContractTransactionRequest,
+} from './contractTransactionRequests';
 
 type ArbOwnerAbi = typeof arbOwnerABI;
 export type ArbOwnerPrepareTransactionRequestFunctionName = GetFunctionName<ArbOwnerAbi>;
 export type ArbOwnerEncodeFunctionDataParameters<
   TFunctionName extends ArbOwnerPrepareTransactionRequestFunctionName,
-> = EncodeFunctionDataParameters<ArbOwnerAbi, TFunctionName>;
-
-function arbOwnerEncodeFunctionData<
-  TFunctionName extends ArbOwnerPrepareTransactionRequestFunctionName,
->({ functionName, abi, args }: ArbOwnerEncodeFunctionDataParameters<TFunctionName>) {
-  return encodeFunctionData({
-    abi,
-    functionName,
-    args,
-  });
-}
+> = ContractEncodeFunctionDataParameters<ArbOwnerAbi, TFunctionName>;
 
 export type ArbOwnerPrepareFunctionDataParameters<
   TFunctionName extends ArbOwnerPrepareTransactionRequestFunctionName,
@@ -38,29 +25,10 @@ export type ArbOwnerPrepareFunctionDataParameters<
 export function arbOwnerPrepareFunctionData<
   TFunctionName extends ArbOwnerPrepareTransactionRequestFunctionName,
 >(params: ArbOwnerPrepareFunctionDataParameters<TFunctionName>) {
-  const { upgradeExecutor } = params;
-
-  if (!upgradeExecutor) {
-    return {
-      to: arbOwnerAddress,
-      data: arbOwnerEncodeFunctionData(
-        params as ArbOwnerEncodeFunctionDataParameters<TFunctionName>,
-      ),
-      value: BigInt(0),
-    };
-  }
-
-  return {
-    to: upgradeExecutor,
-    data: upgradeExecutorEncodeFunctionData({
-      functionName: 'executeCall',
-      args: [
-        arbOwnerAddress, // target
-        arbOwnerEncodeFunctionData(params as ArbOwnerEncodeFunctionDataParameters<TFunctionName>), // targetCallData
-      ],
-    }),
-    value: BigInt(0),
-  };
+  return prepareContractCallParameters({
+    ...params,
+    to: arbOwnerAddress,
+  });
 }
 
 export type ArbOwnerPrepareTransactionRequestParameters<
@@ -81,19 +49,16 @@ export async function arbOwnerPrepareTransactionRequest<
     throw new Error('[arbOwnerPrepareTransactionRequest] client.chain is undefined');
   }
 
-  // params is extending ArbOwnerPrepareFunctionDataParameters, it's safe to cast
-  const { to, data, value } = arbOwnerPrepareFunctionData({
+  const request = await prepareContractTransactionRequest<
+    ArbOwnerAbi,
+    TFunctionName,
+    Transport,
+    TChain
+  >(client, {
     ...params,
     abi: arbOwnerABI,
-  } as unknown as ArbOwnerPrepareFunctionDataParameters<TFunctionName>);
-
-  // @ts-expect-error -- todo: fix viem type issue
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
-    to,
-    data,
-    value,
-    account: params.account,
+    to: arbOwnerAddress,
+    chainId: client.chain.id,
     // if the base gas limit override was provided, hardcode gas to 0 to skip estimation
     // we'll set the actual value in the code below
     gas: typeof params.gasOverrides?.gasLimit?.base !== 'undefined' ? 0n : undefined,
@@ -108,5 +73,5 @@ export async function arbOwnerPrepareTransactionRequest<
     });
   }
 
-  return { ...request, chainId: client.chain.id };
+  return request;
 }

--- a/src/contractTransactionRequests.ts
+++ b/src/contractTransactionRequests.ts
@@ -1,0 +1,112 @@
+import {
+  Abi,
+  Address,
+  Chain,
+  encodeFunctionData as viemEncodeFunctionData,
+  EncodeFunctionDataParameters as ViemEncodeFunctionDataParameters,
+  Hex,
+  PublicClient,
+  Transport,
+} from 'viem';
+import {
+  upgradeExecutorEncodeFunctionData,
+  UpgradeExecutorFunctionName,
+} from './upgradeExecutorEncodeFunctionData';
+import { GetFunctionName } from './types/utils';
+
+type ContractFunctionName<TAbi extends Abi> = GetFunctionName<TAbi>;
+
+export type ContractEncodeFunctionDataParameters<
+  TAbi extends Abi,
+  TFunctionName extends ContractFunctionName<TAbi>,
+> = ViemEncodeFunctionDataParameters<TAbi, TFunctionName>;
+
+type PrepareContractCallParameters<
+  TAbi extends Abi,
+  TFunctionName extends ContractFunctionName<TAbi>,
+> = Omit<ContractEncodeFunctionDataParameters<TAbi, TFunctionName>, 'abi'> & {
+  abi: TAbi;
+  to: Address;
+  upgradeExecutor: Address | false;
+  value?: bigint;
+  upgradeExecutorFunctionName?: Extract<UpgradeExecutorFunctionName, 'execute' | 'executeCall'>;
+};
+
+type PreparedContractCallParameters = {
+  to: Address;
+  data: Hex;
+  value: bigint;
+};
+
+function encodeContractFunctionData<
+  TAbi extends Abi,
+  TFunctionName extends ContractFunctionName<TAbi>,
+>({ abi, functionName, args }: PrepareContractCallParameters<TAbi, TFunctionName>) {
+  return viemEncodeFunctionData({
+    abi,
+    functionName,
+    args,
+  } as unknown as ViemEncodeFunctionDataParameters<TAbi, TFunctionName>);
+}
+
+export function prepareContractCallParameters<
+  TAbi extends Abi,
+  TFunctionName extends ContractFunctionName<TAbi>,
+>(params: PrepareContractCallParameters<TAbi, TFunctionName>): PreparedContractCallParameters {
+  const { upgradeExecutor, value = BigInt(0) } = params;
+  const data = encodeContractFunctionData(params);
+
+  if (!upgradeExecutor) {
+    return {
+      to: params.to,
+      data,
+      value,
+    };
+  }
+
+  return {
+    to: upgradeExecutor,
+    data: upgradeExecutorEncodeFunctionData({
+      functionName: params.upgradeExecutorFunctionName ?? 'executeCall',
+      args: [
+        params.to, // target
+        data, // targetCallData
+      ],
+    }),
+    value,
+  };
+}
+
+type PrepareContractTransactionRequestParameters<
+  TAbi extends Abi,
+  TFunctionName extends ContractFunctionName<TAbi>,
+> = PrepareContractCallParameters<TAbi, TFunctionName> & {
+  account: Address;
+  chainId: number;
+  gas?: bigint;
+};
+
+export async function prepareContractTransactionRequest<
+  TAbi extends Abi,
+  TFunctionName extends ContractFunctionName<TAbi>,
+  TTransport extends Transport = Transport,
+  TChain extends Chain | undefined = Chain | undefined,
+>(
+  client: PublicClient<TTransport, TChain>,
+  params: PrepareContractTransactionRequestParameters<TAbi, TFunctionName>,
+) {
+  const { account, chainId, gas } = params;
+  const { to, data, value } = prepareContractCallParameters<TAbi, TFunctionName>(params);
+
+  // @ts-expect-error -- todo: fix viem type issue
+  const request = await client.prepareTransactionRequest({
+    chain: client.chain,
+    to,
+    data,
+    value,
+    account,
+    gas,
+  });
+
+  return { ...request, chainId };
+}

--- a/src/contractTransactionRequests.ts
+++ b/src/contractTransactionRequests.ts
@@ -108,5 +108,5 @@ export async function prepareContractTransactionRequest<
     gas,
   });
 
-  return { ...request, chainId };
+  return { ...request, gas: request.gas, chainId };
 }

--- a/src/prepareUpgradeExecutorCallParameters.ts
+++ b/src/prepareUpgradeExecutorCallParameters.ts
@@ -1,16 +1,13 @@
-import {
-  Address,
-  encodeFunctionData as viemEncodeFunctionData,
-  EncodeFunctionDataParameters as ViemEncodeFunctionDataParameters,
-} from 'viem';
+import { Address } from 'viem';
 import { GetFunctionName } from './types/utils';
 import { sequencerInboxABI } from './contracts/SequencerInbox';
 import { arbOwnerABI } from './contracts/ArbOwner';
 import { inboxABI } from './contracts/Inbox';
+import { UpgradeExecutorFunctionName } from './upgradeExecutorEncodeFunctionData';
 import {
-  upgradeExecutorEncodeFunctionData,
-  UpgradeExecutorFunctionName,
-} from './upgradeExecutorEncodeFunctionData';
+  ContractEncodeFunctionDataParameters,
+  prepareContractCallParameters,
+} from './contractTransactionRequests';
 
 type ABIs = typeof sequencerInboxABI | typeof arbOwnerABI | typeof inboxABI;
 type FunctionName<TAbi extends ABIs> = GetFunctionName<TAbi>;
@@ -18,60 +15,22 @@ type FunctionName<TAbi extends ABIs> = GetFunctionName<TAbi>;
 type EncodeFunctionDataParameters<
   TAbi extends ABIs,
   TFunctionName extends FunctionName<TAbi>,
-> = ViemEncodeFunctionDataParameters<TAbi, TFunctionName>;
+> = ContractEncodeFunctionDataParameters<TAbi, TFunctionName>;
 
-function encodeFunctionData<TAbi extends ABIs, TFunctionName extends GetFunctionName<TAbi>>({
-  abi,
-  functionName,
-  args,
-}: EncodeFunctionDataParameters<TAbi, TFunctionName>) {
-  return viemEncodeFunctionData({
-    abi,
-    functionName,
-    args,
-  } as unknown as ViemEncodeFunctionDataParameters<TAbi, TFunctionName>);
-}
+type PrepareUpgradeExecutorCallParameters<
+  TAbi extends ABIs,
+  TFunctionName extends FunctionName<TAbi>,
+> = Omit<EncodeFunctionDataParameters<TAbi, TFunctionName>, 'abi'> & {
+  abi: TAbi;
+  to: Address;
+  upgradeExecutor: Address | false;
+  value?: bigint;
+  upgradeExecutorFunctionName?: Extract<UpgradeExecutorFunctionName, 'execute' | 'executeCall'>;
+};
 
 export function prepareUpgradeExecutorCallParameters<
   TAbi extends ABIs,
   TFunctionName extends FunctionName<TAbi>,
->(
-  params: EncodeFunctionDataParameters<TAbi, TFunctionName> &
-    (
-      | {
-          to: Address;
-          upgradeExecutor: false;
-          value?: bigint;
-        }
-      | {
-          to: Address;
-          upgradeExecutor: Address;
-          value?: bigint;
-          upgradeExecutorFunctionName?: Extract<
-            UpgradeExecutorFunctionName,
-            'execute' | 'executeCall'
-          >;
-        }
-    ),
-) {
-  const { upgradeExecutor, value = BigInt(0) } = params;
-  if (!upgradeExecutor) {
-    return {
-      to: params.to,
-      data: encodeFunctionData(params),
-      value,
-    };
-  }
-
-  return {
-    to: upgradeExecutor,
-    data: upgradeExecutorEncodeFunctionData({
-      functionName: params.upgradeExecutorFunctionName ?? 'executeCall',
-      args: [
-        params.to, // target
-        encodeFunctionData(params), // targetCallData
-      ],
-    }),
-    value,
-  };
+>(params: PrepareUpgradeExecutorCallParameters<TAbi, TFunctionName>) {
+  return prepareContractCallParameters<TAbi, TFunctionName>(params);
 }

--- a/src/rollupAdminLogicPrepareTransactionRequest.ts
+++ b/src/rollupAdminLogicPrepareTransactionRequest.ts
@@ -1,36 +1,21 @@
-import {
-  PublicClient,
-  encodeFunctionData,
-  EncodeFunctionDataParameters,
-  Address,
-  Transport,
-  Chain,
-} from 'viem';
+import { PublicClient, Address, Transport, Chain } from 'viem';
 
 import { rollupABI } from './contracts/Rollup';
 
-import { upgradeExecutorEncodeFunctionData } from './upgradeExecutorEncodeFunctionData';
 import { GetFunctionName } from './types/utils';
 import { validateParentChain } from './types/ParentChain';
+import {
+  ContractEncodeFunctionDataParameters,
+  prepareContractCallParameters,
+  prepareContractTransactionRequest,
+} from './contractTransactionRequests';
 
 export type RollupAdminLogicAbi = typeof rollupABI;
 export type RollupAdminLogicFunctionName = GetFunctionName<RollupAdminLogicAbi>;
 
 type RollupAdminLogicEncodeFunctionDataParameters<
   TFunctionName extends RollupAdminLogicFunctionName,
-> = EncodeFunctionDataParameters<RollupAdminLogicAbi, TFunctionName>;
-
-function rollupAdminLogicEncodeFunctionData<TFunctionName extends RollupAdminLogicFunctionName>({
-  abi,
-  functionName,
-  args,
-}: RollupAdminLogicEncodeFunctionDataParameters<TFunctionName>) {
-  return encodeFunctionData({
-    abi,
-    functionName,
-    args,
-  });
-}
+> = ContractEncodeFunctionDataParameters<RollupAdminLogicAbi, TFunctionName>;
 
 export type RollupAdminLogicPrepareFunctionDataParameters<
   TFunctionName extends RollupAdminLogicFunctionName,
@@ -43,31 +28,10 @@ export type RollupAdminLogicPrepareFunctionDataParameters<
 export function rollupAdminLogicPrepareFunctionData<
   TFunctionName extends RollupAdminLogicFunctionName,
 >(params: RollupAdminLogicPrepareFunctionDataParameters<TFunctionName>) {
-  const { upgradeExecutor } = params;
-
-  if (!upgradeExecutor) {
-    return {
-      to: params.rollup,
-      data: rollupAdminLogicEncodeFunctionData(
-        params as RollupAdminLogicEncodeFunctionDataParameters<TFunctionName>,
-      ),
-      value: BigInt(0),
-    };
-  }
-
-  return {
-    to: upgradeExecutor,
-    data: upgradeExecutorEncodeFunctionData({
-      functionName: 'executeCall',
-      args: [
-        params.rollup, // target
-        rollupAdminLogicEncodeFunctionData(
-          params as RollupAdminLogicEncodeFunctionDataParameters<TFunctionName>,
-        ), // targetCallData
-      ],
-    }),
-    value: BigInt(0),
-  };
+  return prepareContractCallParameters({
+    ...params,
+    to: params.rollup,
+  });
 }
 
 export type RollupAdminLogicPrepareTransactionRequestParameters<
@@ -86,20 +50,13 @@ export async function rollupAdminLogicPrepareTransactionRequest<
 ) {
   const { chainId } = validateParentChain(client);
 
-  // params is extending RollupAdminLogicPrepareFunctionDataParameters, it's safe to cast
-  const { to, data, value } = rollupAdminLogicPrepareFunctionData({
-    ...params,
-    abi: rollupABI,
-  } as unknown as RollupAdminLogicPrepareFunctionDataParameters<TFunctionName>);
-
-  // @ts-expect-error -- todo: fix viem type issue
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
-    to,
-    data,
-    value,
-    account: params.account,
-  });
-
-  return { ...request, chainId };
+  return prepareContractTransactionRequest<RollupAdminLogicAbi, TFunctionName, TTransport, TChain>(
+    client,
+    {
+      ...params,
+      abi: rollupABI,
+      to: params.rollup,
+      chainId,
+    },
+  );
 }

--- a/src/sequencerInboxPrepareTransactionRequest.ts
+++ b/src/sequencerInboxPrepareTransactionRequest.ts
@@ -1,34 +1,19 @@
-import {
-  PublicClient,
-  encodeFunctionData,
-  EncodeFunctionDataParameters,
-  Address,
-  Transport,
-  Chain,
-} from 'viem';
+import { PublicClient, Address, Transport, Chain } from 'viem';
 
 import { sequencerInboxABI } from './contracts/SequencerInbox';
-import { upgradeExecutorEncodeFunctionData } from './upgradeExecutorEncodeFunctionData';
 import { GetFunctionName } from './types/utils';
 import { validateParentChain } from './types/ParentChain';
+import {
+  ContractEncodeFunctionDataParameters,
+  prepareContractCallParameters,
+  prepareContractTransactionRequest,
+} from './contractTransactionRequests';
 
 export type SequencerInboxAbi = typeof sequencerInboxABI;
 export type SequencerInboxFunctionName = GetFunctionName<SequencerInboxAbi>;
 
 type SequencerInboxEncodeFunctionDataParameters<TFunctionName extends SequencerInboxFunctionName> =
-  EncodeFunctionDataParameters<SequencerInboxAbi, TFunctionName>;
-
-function sequencerInboxEncodeFunctionData<TFunctionName extends SequencerInboxFunctionName>({
-  abi,
-  functionName,
-  args,
-}: SequencerInboxEncodeFunctionDataParameters<TFunctionName>) {
-  return encodeFunctionData({
-    abi,
-    functionName,
-    args,
-  });
-}
+  ContractEncodeFunctionDataParameters<SequencerInboxAbi, TFunctionName>;
 
 export type SequencerInboxPrepareFunctionDataParameters<
   TFunctionName extends SequencerInboxFunctionName,
@@ -41,31 +26,10 @@ export type SequencerInboxPrepareFunctionDataParameters<
 export function sequencerInboxPrepareFunctionData<TFunctionName extends SequencerInboxFunctionName>(
   params: SequencerInboxPrepareFunctionDataParameters<TFunctionName>,
 ) {
-  const { upgradeExecutor } = params;
-
-  if (!upgradeExecutor) {
-    return {
-      to: params.sequencerInbox,
-      data: sequencerInboxEncodeFunctionData(
-        params as SequencerInboxEncodeFunctionDataParameters<TFunctionName>,
-      ),
-      value: BigInt(0),
-    };
-  }
-
-  return {
-    to: upgradeExecutor,
-    data: upgradeExecutorEncodeFunctionData({
-      functionName: 'executeCall',
-      args: [
-        params.sequencerInbox, // target
-        sequencerInboxEncodeFunctionData(
-          params as SequencerInboxEncodeFunctionDataParameters<TFunctionName>,
-        ), // targetCallData
-      ],
-    }),
-    value: BigInt(0),
-  };
+  return prepareContractCallParameters({
+    ...params,
+    to: params.sequencerInbox,
+  });
 }
 
 export type SequencerInboxPrepareTransactionRequestParameters<
@@ -84,20 +48,13 @@ export async function sequencerInboxPrepareTransactionRequest<
 ) {
   const { chainId } = validateParentChain(client);
 
-  // params is extending SequencerInboxPrepareFunctionDataParameters, it's safe to cast
-  const { to, data, value } = sequencerInboxPrepareFunctionData({
-    ...params,
-    abi: sequencerInboxABI,
-  } as unknown as SequencerInboxPrepareFunctionDataParameters<TFunctionName>);
-
-  // @ts-expect-error -- todo: fix viem type issue
-  const request = await client.prepareTransactionRequest({
-    chain: client.chain,
-    to,
-    data,
-    value,
-    account: params.account,
-  });
-
-  return { ...request, chainId };
+  return prepareContractTransactionRequest<SequencerInboxAbi, TFunctionName, TTransport, TChain>(
+    client,
+    {
+      ...params,
+      abi: sequencerInboxABI,
+      to: params.sequencerInbox,
+      chainId,
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Add shared contract transaction request helpers in `src/contractTransactionRequests.ts`.
- Replace repeated encode/upgrade-executor/prepare-transaction request logic across owner, sequencer inbox, rollup admin, aggregator, and action builders.

## Why / Context
- Several transaction request builders were manually repeating the same flow: encode contract call data, optionally wrap it through the upgrade executor, prepare the transaction request, and return the request with `chainId`.
- Centralizing that flow reduces duplicated implementation code while keeping call-specific ABI, target address, account, gas, and upgrade executor parameters explicit at each call site.