### PR TITLE
feat: require insecure flag to output private keys to node config json

### DIFF
--- a/examples/prepare-node-config/.env.example
+++ b/examples/prepare-node-config/.env.example
@@ -1,5 +1,7 @@
 # Required
 ORBIT_DEPLOYMENT_TRANSACTION_HASH=
+
+# Required only when running with --insecure. This embeds the private keys in node-config.json.
 BATCH_POSTER_PRIVATE_KEY=
 VALIDATOR_PRIVATE_KEY=
 

--- a/examples/prepare-node-config/README.md
+++ b/examples/prepare-node-config/README.md
@@ -1,0 +1,133 @@
+# Prepare a Nitro node configuration
+
+This example creates a `node-config.json` file for a deployed Arbitrum chain. The file
+contains the chain configuration, core contract addresses, parent-chain connection, RPC
+settings, and Nitro node roles.
+
+Private keys are not written by default. Adding either the batch-poster or validator private
+key requires two explicit opt-ins:
+
+- The SDK call must set `insecure: true`.
+- This example must be run with `--insecure`.
+
+## Setup
+
+Create the environment file and configure the deployment transaction and RPC endpoints:
+
+```bash
+cp .env.example .env
+```
+
+`ORBIT_DEPLOYMENT_TRANSACTION_HASH` identifies the transaction from which the example obtains
+the chain configuration and core contract addresses.
+
+## Generate a key-free configuration
+
+Run the example without `--insecure`:
+
+```bash
+pnpm dev
+```
+
+This is equivalent to calling:
+
+```typescript
+prepareNodeConfig({
+  insecure: false,
+  // No private keys
+  // ...
+});
+```
+
+If either private-key environment variable is present, the example warns that it was ignored.
+The resulting `node-config.json` contains no wallet private keys. Review RPC URLs and any
+additional settings for other credentials before treating it as a non-secret deployment
+artifact.
+
+Because no keys were provided, `prepareNodeConfig` disables the batch-poster and staker roles.
+A production runtime must enable the roles it intends to operate when it injects their
+credentials.
+
+As a defense-in-depth CI check, reject generated files containing a `private-key` property:
+
+```bash
+if jq -e '[.. | objects | select(has("private-key"))] | length > 0' node-config.json; then
+  echo "Private key found in node-config.json"
+  exit 1
+fi
+```
+
+## Production workflow
+
+The recommended production model is a non-secret configuration artifact plus credentials
+injected by the runtime. Do not use `--insecure` in the normal production path.
+
+### 1. Store the key-free configuration
+
+Generate `node-config.json` with `insecure: false`, review it, and store it in the deployment
+artifact or configuration system. Mount it read-only in the Nitro container.
+
+Nitro loads a JSON configuration file with:
+
+```bash
+nitro --conf.file=/config/node-config.json
+```
+
+See the official documentation for
+[generating a node configuration with the Chain SDK](https://docs.arbitrum.io/launch-arbitrum-chain/deploy/configure-node)
+and [mounting a Nitro configuration file](https://docs.arbitrum.io/run-arbitrum-node/run-full-node#node-config-file).
+
+### 2. Store credentials separately
+
+Keep the batch-poster and validator credentials in a production secret manager, such as
+Vault, a cloud secret manager, or an external Kubernetes secret provider. Prefer an external
+signer backed by KMS or an HSM where the deployment supports it.
+
+Use separate accounts for the batch poster and active validator. Each account has different
+funding and authorization requirements, and Nitro rejects using the same active address for
+both roles.
+
+### 3. Inject secrets and role settings at startup
+
+Start Nitro with an environment-variable prefix:
+
+```bash
+nitro \
+  --conf.file=/config/node-config.json \
+  --conf.env-prefix=NITRO
+```
+
+Have the orchestrator populate the following variables from its secret provider:
+
+```text
+NITRO_NODE_BATCH__POSTER_ENABLE=true
+NITRO_NODE_BATCH__POSTER_PARENT__CHAIN__WALLET_PRIVATE__KEY=<64 hex characters>
+
+NITRO_NODE_STAKER_ENABLE=true
+NITRO_NODE_STAKER_STRATEGY=MakeNodes
+NITRO_NODE_STAKER_PARENT__CHAIN__WALLET_PRIVATE__KEY=<64 hex characters>
+```
+
+Private keys passed directly to Nitro must omit the `0x` prefix, matching the format produced
+by `prepareNodeConfig`.
+
+Nitro converts a single underscore to a configuration dot and a double underscore to a
+hyphen. Environment variables are applied after configuration files and CLI flags, so they
+override the disabled roles in the key-free template. See
+[Nitro configuration precedence and environment variables](https://docs.arbitrum.io/run-arbitrum-node/nitro/configuration-system#environment-variables).
+
+Only inject the variables required by that process. For example, a dedicated batch-poster
+node should not receive the validator key.
+
+## Explicitly embedding private keys
+
+For isolated development only, private keys can be deliberately embedded:
+
+```bash
+pnpm dev -- --insecure
+chmod 600 node-config.json
+```
+
+Both `BATCH_POSTER_PRIVATE_KEY` and `VALIDATOR_PRIVATE_KEY` must be set. The resulting file is
+a secret: never commit it, place it in a normal deployment artifact, or persist it in a
+production configuration store.

--- a/examples/prepare-node-config/index.ts
+++ b/examples/prepare-node-config/index.ts
@@ -1,4 +1,5 @@
 import { writeFile } from 'fs/promises';
+import { parseArgs } from 'node:util';
 import { Chain, createPublicClient, http } from 'viem';
 import { arbitrumSepolia } from 'viem/chains';
 import {
@@ -10,7 +11,21 @@ import {
 } from '@arbitrum/chain-sdk';
 import { getParentChainLayer } from '@arbitrum/chain-sdk/utils';
 import { config } from 'dotenv';
+import { getPrivateKeyParams } from './options.js';
 config();
+
+const {
+  values: { insecure },
+} = parseArgs({
+  options: {
+    insecure: {
+      type: 'boolean',
+      default: false,
+    },
+  },
+});
+
+const privateKeyParams = getPrivateKeyParams(insecure);
 
 function getRpcUrl(chain: Chain) {
   return chain.rpcUrls.default.http[0];
@@ -20,12 +35,10 @@ if (typeof process.env.ORBIT_DEPLOYMENT_TRANSACTION_HASH === 'undefined') {
   throw new Error(`Please provide the "ORBIT_DEPLOYMENT_TRANSACTION_HASH" environment variable`);
 }
 
-if (typeof process.env.BATCH_POSTER_PRIVATE_KEY === 'undefined') {
-  throw new Error(`Please provide the "BATCH_POSTER_PRIVATE_KEY" environment variable`);
-}
-
-if (typeof process.env.VALIDATOR_PRIVATE_KEY === 'undefined') {
-  throw new Error(`Please provide the "VALIDATOR_PRIVATE_KEY" environment variable`);
+if (!insecure && (process.env.BATCH_POSTER_PRIVATE_KEY || process.env.VALIDATOR_PRIVATE_KEY)) {
+  console.warn(
+    `Private keys will not be written to "node-config.json". Pass "--insecure" to explicitly allow embedding them.`,
+  );
 }
 
 if (typeof process.env.PARENT_CHAIN_RPC === 'undefined' || process.env.PARENT_CHAIN_RPC === '') {
@@ -72,11 +85,11 @@ async function main() {
 
   // prepare the node config
   const nodeConfigParameters: PrepareNodeConfigParams = {
+    insecure,
     chainName: 'My Orbit Chain',
     chainConfig,
     coreContracts,
-    batchPosterPrivateKey: process.env.BATCH_POSTER_PRIVATE_KEY as `0x${string}`,
-    validatorPrivateKey: process.env.VALIDATOR_PRIVATE_KEY as `0x${string}`,
+    ...privateKeyParams,
     stakeToken: config.stakeToken,
     parentChainId: parentChain.id,
     parentChainRpcUrl: getRpcUrl(parentChain),

--- a/examples/prepare-node-config/options.ts
+++ b/examples/prepare-node-config/options.ts
@@ -1,0 +1,30 @@
+export function getPrivateKeyParams(
+  insecure: boolean,
+  environment: NodeJS.ProcessEnv = process.env,
+): {
+  batchPosterPrivateKey?: string;
+  validatorPrivateKey?: string;
+} {
+  if (!insecure) {
+    return {};
+  }
+
+  const batchPosterPrivateKey = environment.BATCH_POSTER_PRIVATE_KEY;
+  if (!batchPosterPrivateKey) {
+    throw new Error(
+      `Please provide the "BATCH_POSTER_PRIVATE_KEY" environment variable when using "--insecure"`,
+    );
+  }
+
+  const validatorPrivateKey = environment.VALIDATOR_PRIVATE_KEY;
+  if (!validatorPrivateKey) {
+    throw new Error(
+      `Please provide the "VALIDATOR_PRIVATE_KEY" environment variable when using "--insecure"`,
+    );
+  }
+
+  return {
+    batchPosterPrivateKey,
+    validatorPrivateKey,
+  };
+}

--- a/examples/prepare-node-config/package.json
+++ b/examples/prepare-node-config/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,10 @@ importers:
         version: 5.2.2
 
   examples/prepare-node-config:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -3475,7 +3479,7 @@ snapshots:
 
   '@safe-global/safe-core-sdk-types@5.1.0(typescript@5.2.2)(zod@4.3.6)':
     dependencies:
-      abitype: 1.0.5(typescript@5.2.2)(zod@4.3.6)
+      abitype: 1.2.4(typescript@5.2.2)(zod@4.3.6)
     transitivePeerDependencies:
       - typescript
       - zod

--- a/src/prepareNodeConfig.ts
+++ b/src/prepareNodeConfig.ts
@@ -25,6 +25,8 @@ function stringifyBackendsJson(
 }
 
 export type PrepareNodeConfigParams = {
+  /** Must be true to include private keys in the returned node config. */
+  insecure: boolean;
   chainName: string;
   chainConfig: ChainConfig;
   coreContracts: CoreContracts;
@@ -47,6 +49,7 @@ function getDisableBlobReader(parentChainId: ParentChainId): boolean {
 }
 
 export function prepareNodeConfig({
+  insecure,
   chainName,
   chainConfig,
   coreContracts,
@@ -59,6 +62,10 @@ export function prepareNodeConfig({
   parentChainBeaconRpcUrl,
   dasServerUrl,
 }: PrepareNodeConfigParams): NodeConfig {
+  if (!insecure && (batchPosterPrivateKey !== undefined || validatorPrivateKey !== undefined)) {
+    throw new Error(`"params.insecure" must be true to include private keys in the node config.`);
+  }
+
   // For L2 Orbit chains settling to Ethereum mainnet or testnet, a parentChainBeaconRpcUrl is enforced
   if (getParentChainLayer(parentChainId) === 1 && !parentChainBeaconRpcUrl) {
     throw new Error(`"parentChainBeaconRpcUrl" is required for L2 Orbit chains.`);

--- a/src/prepareNodeConfig.unit.test.ts
+++ b/src/prepareNodeConfig.unit.test.ts
@@ -1,0 +1,67 @@
+import { expect, it } from 'vitest';
+import { zeroAddress } from 'viem';
+import { arbitrumSepolia } from 'viem/chains';
+import { prepareChainConfig } from './prepareChainConfig';
+import { PrepareNodeConfigParams, prepareNodeConfig } from './prepareNodeConfig';
+
+const privateKey = `0x${'1'.repeat(64)}`;
+
+const params: PrepareNodeConfigParams = {
+  insecure: false,
+  chainName: 'Test Orbit Chain',
+  chainConfig: prepareChainConfig({
+    chainId: 123456,
+    arbitrum: {
+      InitialChainOwner: zeroAddress,
+    },
+  }),
+  coreContracts: {
+    rollup: zeroAddress,
+    nativeToken: zeroAddress,
+    inbox: zeroAddress,
+    outbox: zeroAddress,
+    rollupEventInbox: zeroAddress,
+    challengeManager: zeroAddress,
+    adminProxy: zeroAddress,
+    sequencerInbox: zeroAddress,
+    bridge: zeroAddress,
+    upgradeExecutor: zeroAddress,
+    validatorUtils: zeroAddress,
+    validatorWalletCreator: zeroAddress,
+    deployedAtBlockNumber: 1,
+  },
+  stakeToken: zeroAddress,
+  parentChainId: arbitrumSepolia.id,
+  parentChainRpcUrl: 'http://localhost:8545',
+};
+
+it('omits private keys when insecure is false', () => {
+  const config = prepareNodeConfig(params);
+
+  expect(config.node?.['batch-poster']?.['parent-chain-wallet']).toBeUndefined();
+  expect(config.node?.staker?.['parent-chain-wallet']).toBeUndefined();
+});
+
+it('rejects private keys when insecure is false', () => {
+  expect(() =>
+    prepareNodeConfig({
+      ...params,
+      batchPosterPrivateKey: privateKey,
+    }),
+  ).toThrowError(`"params.insecure" must be true to include private keys in the node config.`);
+});
+
+it('includes private keys when insecure is true', () => {
+  const config = prepareNodeConfig({
+    ...params,
+    insecure: true,
+    batchPosterPrivateKey: privateKey,
+    validatorPrivateKey: privateKey,
+  });
+
+  const sanitizedPrivateKey = privateKey.slice(2);
+  expect(config.node?.['batch-poster']?.['parent-chain-wallet']?.['private-key']).toBe(
+    sanitizedPrivateKey,
+  );
+  expect(config.node?.staker?.['parent-chain-wallet']?.['private-key']).toBe(sanitizedPrivateKey);
+});

--- a/src/scripting/schemaCoverage.unit.test.ts
+++ b/src/scripting/schemaCoverage.unit.test.ts
@@ -278,9 +278,16 @@ const coverageConfig: Record<string, CoverageConfig> = {
       {
         matches: (k) => k === 'nodeConfigParams' || k.startsWith('nodeConfigParams.'),
         apply: (base) => {
-          const b = base as { createRollupParams: { config: Record<string, unknown> } };
+          const b = base as {
+            createRollupParams: { config: Record<string, unknown> };
+            nodeConfigParams?: Record<string, unknown>;
+          };
           return {
             ...b,
+            nodeConfigParams: {
+              ...b.nodeConfigParams,
+              insecure: true,
+            },
             createRollupParams: {
               ...b.createRollupParams,
               config: {
@@ -350,6 +357,10 @@ const coverageConfig: Record<string, CoverageConfig> = {
       },
       'createRollupParams.config.chainConfig.chainId': {
         'createRollupParams.config.chainId': (v) => String(v),
+      },
+      'nodeConfigParams.insecure': {
+        'nodeConfigParams.batchPosterPrivateKey': (v) => (v ? `0x${'1'.repeat(64)}` : undefined),
+        'nodeConfigParams.validatorPrivateKey': (v) => (v ? `0x${'2'.repeat(64)}` : undefined),
       },
     },
   },

--- a/src/scripting/schemas/prepareNodeConfig.ts
+++ b/src/scripting/schemas/prepareNodeConfig.ts
@@ -5,6 +5,7 @@ import { prepareNodeConfig } from '../../prepareNodeConfig';
 
 export const prepareNodeConfigSchema = parentChainPublicClientSchema
   .extend({
+    insecure: z.boolean(),
     chainName: z.string(),
     chainConfig: chainConfigSchema,
     coreContracts: coreContractsSchema,

--- a/src/scripting/workflows/deployFullChain.ts
+++ b/src/scripting/workflows/deployFullChain.ts
@@ -82,6 +82,7 @@ export const inputSchema = z
       .optional(),
     nodeConfigParams: z
       .object({
+        insecure: z.boolean(),
         batchPosterPrivateKey: privateKeySchema.optional(),
         validatorPrivateKey: privateKeySchema.optional(),
         parentChainBeaconRpcUrl: z.url().optional(),
@@ -93,6 +94,18 @@ export const inputSchema = z
 
 export const schema = inputSchema
   .superRefine((data, ctx) => {
+    if (
+      data.nodeConfigParams &&
+      !data.nodeConfigParams.insecure &&
+      (data.nodeConfigParams.batchPosterPrivateKey || data.nodeConfigParams.validatorPrivateKey)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['nodeConfigParams', 'insecure'],
+        message: `"nodeConfigParams.insecure" must be true to include private keys in the node config.`,
+      });
+    }
+
     const isAnytrust =
       data.createRollupParams.config.chainConfig?.arbitrum?.DataAvailabilityCommittee === true;
     if (data.createRollupParams.keyset && !isAnytrust) {
@@ -341,6 +354,7 @@ export const execute = async (input: z.output<typeof schema>) => {
 
   const nodeConfig = nodeConfigParams
     ? prepareNodeConfig({
+        insecure: nodeConfigParams.insecure,
         chainName,
         chainConfig,
         coreContracts: { ...coreContracts, nativeToken: restParams.nativeToken },


### PR DESCRIPTION
## Summary

- Require the SDK `prepareNodeConfig` API and scripting schemas to receive an explicit `insecure` boolean.
- Reject private-key parameters unless `insecure` is `true`, while generating key-free node configurations by default.
- Update the `prepare-node-config` example with inline `--insecure` parsing, a workspace SDK dependency, and production guidance for runtime secret injection.

## Why / Context

`node-config.json` can embed batch-poster and validator private keys. This change makes that secret exposure an explicit opt-in.

The documented production workflow keeps the persistent configuration key-free and injects credentials through the runtime secret-management system when Nitro starts.